### PR TITLE
Uncomment makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ sonar:
 # .PHONY: test
 # test: test-unit
 
+ .PHONY: security-check
+ security-check:
+ 	npm audit --audit-level=high
+
 .PHONY: package
 package: build
 ifndef version

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,6 @@ sonar:
 # .PHONY: test
 # test: test-unit
 
-# .PHONY: security-check
-# security-check:
-# 	npm audit --audit-level=high
-
 .PHONY: package
 package: build
 ifndef version

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ sonar:
 # test-unit: clean
 # 	npm run coverage
 
-# .PHONY: test
-# test: test-unit
+.PHONY: test
+test: test-unit
 
 .PHONY: security-check
 security-check:

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ lint:
 
 .PHONY: sonar
 sonar:
-# sonar: test-unit
+sonar: test-unit
 	npm run sonarqube
 
-# .PHONY: test-unit
-# test-unit: clean
-# 	npm run coverage
+.PHONY: test-unit
+test-unit: clean
+	npm run coverage
 
 .PHONY: test
 test: test-unit
@@ -54,6 +54,6 @@ endif
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .
 	rm -rf $(tmpdir)
 
-# .PHONY: dist
-# dist: lint test-unit clean package
+.PHONY: dist
+dist: lint test-unit clean package
 

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ sonar:
 # .PHONY: test
 # test: test-unit
 
- .PHONY: security-check
- security-check:
- 	npm audit --audit-level=high
+.PHONY: security-check
+security-check:
+	npm audit --audit-level=high
 
 .PHONY: package
 package: build

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "sonarqube-base-branch": "sonar-scanner",
     "sonarqube-pull-request": "sonar-scanner -D sonar.pullrequest.base=main",
     "start": "node dist/bin/www.js",
-    "test": "jest"
+    "test": "jest",
+    "coverage": "jest --coverage --forceExit --passWithNoTests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
uncomment makefile targets for pipeline security check task to run



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.