### PR TITLE
LP-198 Localisation of the error and 'page not found' screens

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -1,4 +1,8 @@
 {
     "startTitle" : "Partneriaethau Cyfyngedig yw hyn",
-    "errorStartAddressMissing" : "Rhowch gyfeiriad"
+    "errorStartAddressMissing" : "Rhowch gyfeiriad",
+
+    "pageNotFound_Title" : "WELSH - Page Not Found",
+
+    "errorPage_Title" : "WELSH - Sorry, the service is unavailable"
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -1,4 +1,18 @@
 {
     "startTitle" : "This is Limited Partnerships",
-    "errorStartAddressMissing" : "Please enter an address"
+    "errorStartAddressMissing" : "Please enter an address",
+
+    "pageNotFound_Title" : "Page not found",
+    "pageNotFound_Text1" : "If you typed the web address, check it is spelled correctly.",
+    "pageNotFound_Text2" : "If you pasted the web address, check you copied the entire address.",
+    "pageNotFound_Text3" : "If the web address is correct or you selected a link, the page may have moved.",
+    "pageNotFound_Text4_Part1" : "To register a limited partnership, go to the ",
+    "pageNotFound_Text4_HyperlinkText" : "Register a limited partnership",
+    "pageNotFound_Text4_Part2" : " start page.",
+
+    "errorPage_Title" : "Sorry, the service is unavailable",
+    "errorPage_Text1" : "You will be able to use the service at a later date.",
+    "errorPage_Text2_Part1" : "Email ",
+    "errorPage_Text2_EmailAddress" : "enquiries@companieshouse.gov.uk",
+    "errorPage_Text2_Part2" : " if you need more information."
 }

--- a/src/views/error-page.njk
+++ b/src/views/error-page.njk
@@ -1,4 +1,7 @@
+{% extends "layout.njk" %}
+
 {% from "web-security-node/components/csrf-error/macro.njk" import csrfError %}
+
 {% block content %}
   {% if csrfErrors %}
     {{
@@ -7,10 +10,10 @@
   {% else %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-        <p class="govuk-body">You will be able to use the service at a later date.</p>
+        <h1 class="govuk-heading-l">{{ i18n.errorPage_Title }}</h1>
+        <p class="govuk-body">{{ i18n.errorPage_Text1 }}</p>
 
-        <p class="govuk-body">Email <a class="govuk-link" href="mailto: enquiries@companieshouse.gov.uk">enquiries@companieshouse.gov.uk</a> if you need more information.</p>
+        <p class="govuk-body">{{ i18n.errorPage_Text2_Part1 }}<a class="govuk-link" href="mailto: enquiries@companieshouse.gov.uk">{{ i18n.errorPage_Text2_EmailAddress }}</a>{{ i18n.errorPage_Text2_Part2 }}</p>
       </div>
     </div>
   {% endif %}    

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -26,6 +26,10 @@
 {% block beforeContent %}
   {% include "includes/phase_banner.njk" %}
   <div style="margin-bottom: 25px; border-bottom: 1px solid #b1b4b6;">
+
+    {% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
+    {% include "ch-node-utils/templates/locales-banner.njk" %}
+
     {% block backLink %}
     {% endblock %}
     {% block signOutBanner %}

--- a/src/views/page-not-found.njk
+++ b/src/views/page-not-found.njk
@@ -1,14 +1,16 @@
+{% extends "layout.njk" %}
+
 {% block content %}
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-two-thirds">
-			<h1 class="govuk-heading-l">Page not found</h1>
-			<p class="govuk-body">If you typed the web address, check it is spelled correctly.</p>
+			<h1 class="govuk-heading-l">{{ i18n.pageNotFound_Title }}</h1>
+			<p class="govuk-body">{{ i18n.pageNotFound_Text1 }}</p>
 
-			<p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+			<p class="govuk-body">{{ i18n.pageNotFound_Text2 }}</p>
 
-			<p class="govuk-body">If the web address is correct or you selected a link, the page may have moved. </p>
+			<p class="govuk-body">{{ i18n.pageNotFound_Text3 }}</p>
 
-			<p class="govuk-body"> To register an limited partnerships, go to the <a class="govuk-link" href="/limited-partnerships/start">Register an limited partnerships start page.</a> </p>
+			<p class="govuk-body">{{ i18n.pageNotFound_Text4_Part1 }}<a class="govuk-link" href="/limited-partnerships/start">{{ i18n.pageNotFound_Text4_HyperlinkText }}</a>{{ i18n.pageNotFound_Text4_Part2 }}</p>
 		</div>
 	</div>
 {% endblock %}

--- a/src/views/start.njk
+++ b/src/views/start.njk
@@ -2,10 +2,6 @@
 
 {% block content %}
 
-  {# Move these to layout template #}
-  {% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
-  {% include "ch-node-utils/templates/locales-banner.njk" %}
-
   {{ i18n.startTitle }}
 
   <p>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-198

### Change description

Localisation now implemented for the 'error' and 'page not found' screens.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.