### PR TITLE
LP-279 Add i18n text to name page

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -1,4 +1,19 @@
 {
+    "buttons" : {
+        "saveAndContinue" : "WELSH - Save and continue"
+    },
+
+    "namePage" : {
+        "title" : "WELSH - Limited partnership name",
+        "whatIsName" : "WELSH - What is the limited partnership name?",
+        "whatIsNameHint" : "WELSH - Do not enter a name ending, like Limited Partnership or LP. We'll add this for you.",
+        "checkName" : "WELSH - Check the limited partnership name against an existing trademark",
+        "checkNameExistingLP" : "WELSH - You must check the name is not the same as an existing limited partnership on the <a href='#/'>Companies House register (link opens in a new tab)</a>. If it is, we will reject your application.",
+        "checkNameExistingTrademark" : "WELSH - You should also use the <a href='https://www.gov.uk/search-for-trade mark' target='_blank'>trade mark search (link opens in a new tab)</a> to check if your name matches an existing trade mark. If it does, consider choosing a different name. Companies House will not carry out this check for you.",
+        "nameEnding" : "WELSH - Which limited partnership name ending would you prefer to go on the public record?",
+        "nameEndingHint" : "WELSH - There's no difference between the name endings Limited Partnership, LP and L.P. except for how they look."
+    },
+
     "startPage" : {
         "title" : "Partneriaethau Cyfyngedig yw hyn",
         "errorStartAddressMissing" : "Rhowch gyfeiriad"

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -1,4 +1,19 @@
 {
+    "buttons" : {
+        "saveAndContinue" : "Save and continue"
+    },
+
+    "namePage" : {
+        "title" : "Limited partnership name",
+        "whatIsName" : "What is the limited partnership name?",
+        "whatIsNameHint" : "Do not enter a name ending, like Limited Partnership or LP. We'll add this for you.",
+        "checkName" : "Check the limited partnership name against an existing trademark",
+        "checkNameExistingLP" : "You must check the name is not the same as an existing limited partnership on the <a href='#/'>Companies House register (link opens in a new tab)</a>. If it is, we will reject your application.",
+        "checkNameExistingTrademark" : "You should also use the <a href='https://www.gov.uk/search-for-trade mark' target='_blank'>trade mark search (link opens in a new tab)</a> to check if your name matches an existing trade mark. If it does, consider choosing a different name. Companies House will not carry out this check for you.",
+        "nameEnding" : "Which limited partnership name ending would you prefer to go on the public record?",
+        "nameEndingHint" : "There's no difference between the name endings Limited Partnership, LP and L.P. except for how they look."
+    },
+
     "startPage" : {
         "title" : "This is Limited Partnerships",
         "errorStartAddressMissing" : "Please enter an address"
@@ -16,5 +31,5 @@
         "title" : "Sorry, the service is unavailable",
         "tryLater" : "You will be able to use the service at a later date.",
         "moreInfo" : "Email <a class='govuk-link' href='mailto: enquiries@companieshouse.gov.uk'>enquiries@companieshouse.gov.uk</a>, if you need more information."
-    }
+    }   
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sonarqube-base-branch": "sonar-scanner",
     "sonarqube-pull-request": "sonar-scanner -D sonar.pullrequest.base=main",
     "start": "node dist/bin/www.js",
-    "dev": "nodemon src/bin/www.ts",
+    "dev": "nodemon --ext ts,njk,json src/bin/www.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:unit": "jest --testRegex=.spec.ts",

--- a/src/presentation/test/integration/localisation.test.ts
+++ b/src/presentation/test/integration/localisation.test.ts
@@ -9,7 +9,7 @@ import { START_URL } from "../../../presentation/controller/global/Routing";
 
 describe("Localisation tests", () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   const setLocalesEnabled = (bool: boolean) => {

--- a/src/presentation/test/integration/localisation.test.ts
+++ b/src/presentation/test/integration/localisation.test.ts
@@ -3,8 +3,8 @@ import { LocalesService } from "@companieshouse/ch-node-utils";
 
 import app from "./app";
 import * as config from "../../../config/constants";
-import enStartPageText from "../../../../locales/en/translations.json";
-import cyStartPageText from "../../../../locales/cy/translations.json";
+import enTranslationText from "../../../../locales/en/translations.json";
+import cyTranslationText from "../../../../locales/cy/translations.json";
 import { START_URL } from "../../../presentation/controller/global/Routing";
 
 describe("Localisation tests", () => {
@@ -22,7 +22,7 @@ describe("Localisation tests", () => {
 
     const resp = await request(app).get(START_URL + "?lang=en");
 
-    expect(resp.text).toContain(enStartPageText.startPage.title);
+    expect(resp.text).toContain(enTranslationText.startPage.title);
   });
 
   test("renders the start page with Welsh text when lang is cy", async () => {
@@ -30,7 +30,7 @@ describe("Localisation tests", () => {
 
     const resp = await request(app).get(START_URL + "?lang=cy");
 
-    expect(resp.text).toContain(cyStartPageText.startPage.title);
+    expect(resp.text).toContain(cyTranslationText.startPage.title);
   });
 
   test("renders the start page with English text when an unsupported language is given", async () => {
@@ -38,7 +38,7 @@ describe("Localisation tests", () => {
 
     const resp = await request(app).get(START_URL + "?lang=pp");
 
-    expect(resp.text).toContain(enStartPageText.startPage.title);
+    expect(resp.text).toContain(enTranslationText.startPage.title);
   });
 
   test("renders the start page with English text as default when localisation is switched on", async () => {
@@ -46,7 +46,7 @@ describe("Localisation tests", () => {
 
     const resp = await request(app).get(START_URL);
 
-    expect(resp.text).toContain(enStartPageText.startPage.title);
+    expect(resp.text).toContain(enTranslationText.startPage.title);
     expect(resp.text).toContain("English");
     expect(resp.text).toContain("Cymraeg");
   });
@@ -56,7 +56,7 @@ describe("Localisation tests", () => {
 
     const resp = await request(app).get(START_URL);
 
-    expect(resp.text).toContain(enStartPageText.startPage.title);
+    expect(resp.text).toContain(enTranslationText.startPage.title);
     expect(resp.text).not.toContain("English");
     expect(resp.text).not.toContain("Cymraeg");
   });

--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -1,0 +1,39 @@
+import request from "supertest";
+import { LocalesService } from "@companieshouse/ch-node-utils";
+import * as config from "../../../../config/constants";
+
+import app from "../app";
+import {
+  NAME_URL,
+} from "../../../controller/registration/Routing";
+
+describe("Name Page", () => {
+  beforeEach(() => {
+    setLocalesEnabled(false);
+  });
+
+  const setLocalesEnabled = (bool: boolean) => {
+    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
+    LocalesService.getInstance().enabled = bool;
+  };
+
+  it("should load the name page with Welsh text", async () => {
+    setLocalesEnabled(true);
+    const res = await request(app).get(NAME_URL + "?lang=cy");
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("WELSH - What is the limited partnership name?");
+    expect(res.text).toContain("WELSH - Save and continue");
+  });
+
+  it("should load the name page with English text", async () => {
+    setLocalesEnabled(true);
+    const res = await request(app).get(NAME_URL + "?lang=en");
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("What is the limited partnership name?");
+    expect(res.text).toContain("Save and continue");
+    expect(res.text).not.toContain("WELSH -");
+  });
+
+});

--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -24,6 +24,8 @@ describe("Name Page", () => {
 
     expect(res.status).toBe(200);
     expect(res.text).toContain(cyTranslationText.namePage.title);
+    expect(res.text).toContain(cyTranslationText.namePage.whatIsName);
+    expect(res.text).toContain(cyTranslationText.namePage.nameEnding);
     expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
   });
 
@@ -33,6 +35,8 @@ describe("Name Page", () => {
 
     expect(res.status).toBe(200);
     expect(res.text).toContain(enTranslationText.namePage.title);
+    expect(res.text).toContain(enTranslationText.namePage.whatIsName);
+    expect(res.text).toContain(enTranslationText.namePage.nameEnding);
     expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
     expect(res.text).not.toContain("WELSH -");
   });

--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -1,7 +1,8 @@
 import request from "supertest";
 import { LocalesService } from "@companieshouse/ch-node-utils";
 import * as config from "../../../../config/constants";
-
+import enTranslationText from "../../../../../locales/en/translations.json";
+import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
 import {
   NAME_URL,
@@ -22,8 +23,8 @@ describe("Name Page", () => {
     const res = await request(app).get(NAME_URL + "?lang=cy");
 
     expect(res.status).toBe(200);
-    expect(res.text).toContain("WELSH - What is the limited partnership name?");
-    expect(res.text).toContain("WELSH - Save and continue");
+    expect(res.text).toContain(cyTranslationText.namePage.title);
+    expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
   });
 
   it("should load the name page with English text", async () => {
@@ -31,8 +32,8 @@ describe("Name Page", () => {
     const res = await request(app).get(NAME_URL + "?lang=en");
 
     expect(res.status).toBe(200);
-    expect(res.text).toContain("What is the limited partnership name?");
-    expect(res.text).toContain("Save and continue");
+    expect(res.text).toContain(enTranslationText.namePage.title);
+    expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
     expect(res.text).not.toContain("WELSH -");
   });
 

--- a/src/views/includes/save-and-continue-button.njk
+++ b/src/views/includes/save-and-continue-button.njk
@@ -1,5 +1,5 @@
 {{ govukButton({
-  text: "Save and continue",
+  text: i18n.buttons.saveAndContinue,
   attributes: {
     "id": "submit"
   }

--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -10,12 +10,12 @@
       
       {% include "includes/csrf_token.njk" %}
 
-      <h1 class="govuk-heading-xl">Limited partnership name</h1>
+      <h1 class="govuk-heading-xl">{{ i18n.namePage.title }}</h1>
 
       <div class="govuk-form-group">
         <h1 class="govuk-label-wrapper">
           <label class="govuk-label govuk-label--l" for="partnership_name">
-            What is the limited partnership name?
+            {{ i18n.namePage.whatIsName }}
           </label>
         </h1>
 
@@ -32,7 +32,7 @@
             }
           },
           hint: {
-            text: "Do not enter a name ending, like Limited Partnership or LP. We'll add this for you."
+            text: i18n.namePage.whatIsNameHint
           },
           attributes : {
             required : true,
@@ -49,24 +49,15 @@
       <details class="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            Check the limited partnership name against an existing trademark
+            {{ i18n.namePage.checkName }}
           </span>
         </summary>
         <div class="govuk-details__text">
           <p>
-            You must check the name is not the same as an existing limited
-            partnership on the
-            <a href="#/">Companies House register (link opens in a new tab)</a
-            >. If it is, we will reject your application.
+            {{ i18n.namePage.checkNameExistingLP | safe }}
           </p>
           <p>
-            You should also use the
-            <a href="https://www.gov.uk/search-for-trade mark" target="_blank"
-              >trade mark search (link opens in a new tab)</a
-            >
-            to check if your name matches an existing trade mark. If it does,
-            consider choosing a different name. Companies House will not carry
-            out this check for you.
+            {{ i18n.namePage.checkNameExistingTrademark | safe }}
           </p>
         </div>
       </details>
@@ -75,7 +66,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="nameEnding-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Which limited partnership name ending would you prefer to go on the public record?
+              {{ i18n.namePage.nameEnding }}
             </h1>
           </legend>
 
@@ -129,8 +120,7 @@
               }
             },
             hint: {
-              text: "There's no difference between the name endings Limited
-              Partnership, LP and L.P. except for how they look."
+              text: i18n.namePage.nameEndingHint
             },
             items: [
               {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-211


### Change description
Change the text on the Name page to use localisation and add text to the EN and CY locales/translations files


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.