### PR TITLE
Remove API key from constants

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,6 @@ import {
 
 // APP CONFIG
 export const ACCOUNT_URL = getEnvironmentValue("ACCOUNT_URL");
-export const API_KEY = getEnvironmentValue("CHS_API_KEY");
 export const API_URL = getEnvironmentValue("API_URL");
 export const APPLICATION_NAME = "limited-partnerships-web";
 export const CACHE_SERVER = getEnvironmentValue("CACHE_SERVER");

--- a/src/test/global.setup.ts
+++ b/src/test/global.setup.ts
@@ -1,6 +1,5 @@
 export default () => {
   process.env.ACCOUNT_URL = "https://account.chs.local";
-  process.env.CHS_API_KEY = "CHS_API_KEY";
   process.env.API_URL = "https://api.chs.local:4001";
   process.env.CACHE_SERVER = "redis";
   process.env.CDN_HOST = "cdn.chs.local";


### PR DESCRIPTION
### JIRA link
NA


### Change description
We are getting a property not found error when deploying app into CI-Dev, and it looks like the CHS_API_KEY that it is looking for is no longer used in the service, so removing it to see if it fixes the issue.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.