### PR TITLE
LP-293 Name ending nested radio buttons

### DIFF
--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -7,6 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <form class="form" action={{ props.currentUrl }} method="post">
       <input type="hidden" name="pageType" value={{ props.pageType }}>
+      <input type="hidden" id="name_ending" name="name_ending">
       
       {% include "includes/csrf_token.njk" %}
 
@@ -58,18 +59,16 @@
             </h1>
           </legend>
 
-          {% set welsh %}
+          {% set welshRadios %}
             {{ govukRadios({
               errorMessage: errors.name_ending if errors,
               classes: "govuk-radios",
-              idPrefix: "name_ending",
-              name: "name_ending",
+              idPrefix: "welsh_name_ending",
+              name: "welsh_name_ending",
               items: [
                 {
                   value: "Partneriaeth Cyfyngedig",
                   text: "Partneriaeth Cyfyngedig",
-                  id: "nameEnding-1",
-                  name: "name_ending",
                   attributes: {
                     required: true
                   }
@@ -77,8 +76,6 @@
                 {
                   value: "PC",
                   text: "PC",
-                  id: "nameEnding-2",
-                  name: "name_ending",
                   attributes: {
                     required: true
                   }
@@ -86,8 +83,6 @@
                 {
                   value: "P.C.",
                   text: "P.C.",
-                  id: "nameEnding-3",
-                  name: "name_ending",
                   attributes: {
                     required: true
                   }
@@ -99,8 +94,8 @@
           {{ govukRadios({
             errorMessage: errors.name_ending if errors,
             classes: "govuk-radios",
-            idPrefix: "name_ending",
-            name: "name_ending",
+            idPrefix: "english_name_ending",
+            name: "english_name_ending",
             fieldset: {
               legend: {
                 isPageHeading: false,
@@ -114,8 +109,7 @@
               {
                 value: "Limited Partnership",
                 text: "Limited Partnership",
-                id: "nameEnding-1",
-                name: "name_ending",
+                id: "englishNameEnding-1",
                 attributes: {
                   required: true
                 }
@@ -123,8 +117,7 @@
               {
                 value: "LP",
                 text: "LP",
-                id: "nameEnding-2",
-                name: "name_ending",
+                id: "englishNameEnding-2",
                 attributes: {
                   required: true
                 }
@@ -132,8 +125,7 @@
               {
                 value: "L.P.",
                 text: "L.P.",
-                id: "nameEnding-3",
-                name: "name_ending",
+                id: "englishNameEnding-3",
                 attributes: {
                   required: true
                 }
@@ -141,10 +133,9 @@
               {
                 value: "",
                 text: "A Welsh name ending",
-                id: "nameEnding-4",
-                name: "name_ending",
+                id: "englishNameEnding-4",
                 conditional: {
-                  html: welsh
+                  html: welshRadios
                 }
               }
             ]
@@ -171,13 +162,17 @@
       nameField.reportValidity();
     };
 
+    const name_ending = document.getElementById('name_ending');
     const suffixDiv = document.querySelector('.govuk-input__suffix');
-    const radioButtons = document.querySelectorAll('input[name="name_ending"]');
+    const englishadioButtons = document.querySelectorAll('input[name="english_name_ending"]');
+    const welshRadioButtons = document.querySelectorAll('input[name="welsh_name_ending"]');
+    const allRadioButtons = [...englishRadioButtons, ...welshRadioButtons];
 
-    radioButtons.forEach(function(radioButton) {
+    allRadioButtons.forEach(function(radioButton) {
       radioButton.addEventListener('change', function() {
         if (radioButton.checked) {
           suffixDiv.textContent = radioButton.value;
+          name_ending.value = radioButton.value;
           validateNameLength();
         }
       });

--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -109,7 +109,6 @@
               {
                 value: "Limited Partnership",
                 text: "Limited Partnership",
-                id: "englishNameEnding-1",
                 attributes: {
                   required: true
                 }
@@ -117,7 +116,6 @@
               {
                 value: "LP",
                 text: "LP",
-                id: "englishNameEnding-2",
                 attributes: {
                   required: true
                 }
@@ -125,7 +123,6 @@
               {
                 value: "L.P.",
                 text: "L.P.",
-                id: "englishNameEnding-3",
                 attributes: {
                   required: true
                 }
@@ -133,7 +130,6 @@
               {
                 value: "",
                 text: "A Welsh name ending",
-                id: "englishNameEnding-4",
                 conditional: {
                   html: welshRadios
                 }

--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -164,7 +164,7 @@
 
     const name_ending = document.getElementById('name_ending');
     const suffixDiv = document.querySelector('.govuk-input__suffix');
-    const englishadioButtons = document.querySelectorAll('input[name="english_name_ending"]');
+    const englishRadioButtons = document.querySelectorAll('input[name="english_name_ending"]');
     const welshRadioButtons = document.querySelectorAll('input[name="welsh_name_ending"]');
     const allRadioButtons = [...englishRadioButtons, ...welshRadioButtons];
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-293


### Change description
Draft - Try to find a way to stop the welsh buttons being hidden on selection.
Splitting the radio buttons so they have separate 'name' values on the form seems to stop them being hidden.
Then made 'name_ending' field a hidden field that is populated by javascript on button click.
Seems to work on submitting but might need more javascript to populate the correct button when resuming a journey or populating page from stored data.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.