### PR TITLE
LP-382 Change matomo on name page

### DIFF
--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -94,9 +94,13 @@
         </fieldset>
       </div>
 
-      <button class="govuk-button" data-module="govuk-button" id="submit" onclick="_paq.push(['trackEvent', 'Which limited partnership name ending would you prefer to go on the public record?', document.querySelector('input[name=name_ending]:checked').nextElementSibling.innerHTML])">
-        {{ i18n.buttons.saveAndContinue }}
-      </button>
+      {{ govukButton({
+        text: i18n.buttons.saveAndContinue,
+        attributes: {
+          "id": "submit",
+          "onclick": "_paq.push(['trackEvent', 'Limited Partnerships name', 'name-ending', document.querySelector('input[name=name_ending]:checked').nextElementSibling.innerHTML])"
+        }
+      }) }}
     </form>
   </div>
 </div>

--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -68,7 +68,7 @@
             required : true,
             "aria-describedby": "partnership_name-hint",
             minLength: "1",
-            "data-event-id": "namePage-name"
+            "data-event-id": "name"
           },
           suffix: {
             text: "Limited Partnership"
@@ -94,7 +94,9 @@
         </fieldset>
       </div>
 
-      {% include "includes/save-and-continue-button.njk" %}
+      <button class="govuk-button" data-module="govuk-button" id="submit" onclick="_paq.push(['trackEvent', 'Which limited partnership name ending would you prefer to go on the public record?', document.querySelector('input[name=name_ending]:checked').nextElementSibling.innerHTML])">
+        {{ i18n.buttons.saveAndContinue }}
+      </button>
     </form>
   </div>
 </div>

--- a/src/views/pages/name/options-with-or-without-welsh.njk
+++ b/src/views/pages/name/options-with-or-without-welsh.njk
@@ -6,8 +6,7 @@
       id: "nameEnding-1",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-limitedPartnership"
+        required: true
       }
     },
     {
@@ -16,8 +15,7 @@
       id: "nameEnding-2",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-lp"
+        required: true
       }
     },
     {
@@ -26,8 +24,7 @@
       id: "nameEnding-3",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-lDotP"
+        required: true
       }
     }
   ]
@@ -43,8 +40,7 @@
       id: "nameEnding-4",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-partneriaethCyfyngedig"
+        required: true
       }
     },
     {
@@ -53,8 +49,7 @@
       id: "nameEnding-5",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-pc"
+        required: true
       }
     },
     {
@@ -63,8 +58,7 @@
       id: "nameEnding-6",
       name: "name_ending",
       attributes: {
-        required: true,
-        "data-event-id": "namePage-name-ending-pDotC"
+        required: true
       }
     }
   ), nameEndingOptionsList) %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-382


### Change description
Change the name page radio buttons to only record matomo event on button press and renamed
Event Limited Partnerships name - namepage-name
to
Event Limited Partnerships name - name

<img width="614" alt="Screenshot 2025-01-13 at 15 41 23" src="https://github.com/user-attachments/assets/b54a0da7-9bbe-4301-9c60-6d26eff0b268" />



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.