### PR TITLE
Remove duplication of setLocalesEnabled test function

### DIFF
--- a/src/presentation/test/integration/localisation.test.ts
+++ b/src/presentation/test/integration/localisation.test.ts
@@ -1,21 +1,15 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
 
 import app from "./app";
-import * as config from "../../../config/constants";
 import enTranslationText from "../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../locales/cy/translations.json";
 import { START_URL } from "../../../presentation/controller/global/Routing";
+import { setLocalesEnabled } from "../../../test/test-utils";
 
 describe("Localisation tests", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   test("renders the start page with English text when lang is en", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -1,18 +1,13 @@
 import request from "supertest";
 import app from "../app";
 import { CHECK_YOUR_ANSWERS_URL } from "../../../controller/registration/url";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Check Your Answers Page", () => {
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should GET Check Your Answers Page English text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/email.test.ts
+++ b/src/presentation/test/integration/registration/email.test.ts
@@ -1,6 +1,4 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
@@ -9,6 +7,7 @@ import { appDevDependencies } from "../../../../config/dev-dependencies";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { ApiErrors } from "../../../../domain/entities/UIErrors";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Email Page", () => {
   beforeEach(() => {
@@ -16,11 +15,6 @@ describe("Email Page", () => {
 
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   describe("Get Email Page", () => {
     it("should load the name page with English text", async () => {

--- a/src/presentation/test/integration/registration/general-partner-choice.test.ts
+++ b/src/presentation/test/integration/registration/general-partner-choice.test.ts
@@ -1,6 +1,4 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
@@ -15,6 +13,7 @@ import {
   APPLICATION_CACHE_KEY_PREFIX_REGISTRATION
 } from "../../../../config/constants";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("General Partner Choice Page", () => {
   beforeEach(() => {
@@ -24,11 +23,6 @@ describe("General Partner Choice Page", () => {
     appDevDependencies.limitedPartnershipGateway.feedErrors();
     appDevDependencies.cacheRepository.feedCache(null);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should load the general partner choice page with Welsh text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/general-partners.test.ts
+++ b/src/presentation/test/integration/registration/general-partners.test.ts
@@ -1,12 +1,11 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
 import { GENERAL_PARTNERS_URL } from "../../../controller/registration/url";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("General Partners Page", () => {
   beforeEach(() => {
@@ -14,11 +13,6 @@ describe("General Partners Page", () => {
 
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should load the general partners page with Welsh text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/limited-partner-choice.test.ts
+++ b/src/presentation/test/integration/registration/limited-partner-choice.test.ts
@@ -1,7 +1,4 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-
-import * as constants from "../../../../config/constants";
 import {
   APPLICATION_CACHE_KEY,
   APPLICATION_CACHE_KEY_PREFIX_REGISTRATION
@@ -17,6 +14,7 @@ import {
 import { registrationRoutingLimitedPartnerChoice } from "../../../controller/registration/Routing";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Limited Partner Choice Page", () => {
   beforeEach(() => {
@@ -26,11 +24,6 @@ describe("Limited Partner Choice Page", () => {
     appDevDependencies.limitedPartnershipGateway.feedErrors();
     appDevDependencies.cacheRepository.feedCache(null);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(constants, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should load the limited partner choice page with Welsh text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/limited-partners.test.ts
+++ b/src/presentation/test/integration/registration/limited-partners.test.ts
@@ -1,12 +1,11 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
 import { LIMITED_PARTNERS_URL } from "../../../controller/registration/url";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Limited Partners Page", () => {
   beforeEach(() => {
@@ -14,11 +13,6 @@ describe("Limited Partners Page", () => {
 
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should load the limited partners page with Welsh text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -1,11 +1,9 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
 import {
   NameEndingType,
   PartnershipType
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
-import * as config from "../../../../config/constants";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import app from "../app";
@@ -17,6 +15,7 @@ import { appDevDependencies } from "../../../../config/dev-dependencies";
 import { APPLICATION_CACHE_KEY_PREFIX_REGISTRATION } from "../../../../config/constants";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Name Page", () => {
   beforeEach(() => {
@@ -26,11 +25,6 @@ describe("Name Page", () => {
     appDevDependencies.limitedPartnershipGateway.feedErrors();
     appDevDependencies.cacheRepository.feedCache(null);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   it("should load the name page with Welsh text", async () => {
     setLocalesEnabled(true);

--- a/src/presentation/test/integration/registration/postcode-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/postcode-registered-office-address.test.ts
@@ -1,5 +1,4 @@
 import request from "supertest";
-import { LocalesService } from "@companieshouse/ch-node-utils";
 
 import * as config from "../../../../config/constants";
 
@@ -11,6 +10,7 @@ import app from "../app";
 
 import { POSTCODE_REGISTERED_OFFICE_ADDRESS_URL } from "../../../controller/addressLookUp/url";
 import AddressPageType from "../../../controller/addressLookUp/PageType";
+import { setLocalesEnabled } from "../../../../test/test-utils";
 
 describe("Postcode Registered Office Address Page", () => {
   const address = appDevDependencies.addressLookUpGateway.address;
@@ -20,11 +20,6 @@ describe("Postcode Registered Office Address Page", () => {
 
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
   });
-
-  const setLocalesEnabled = (bool: boolean) => {
-    jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
-    LocalesService.getInstance().enabled = bool;
-  };
 
   describe("Get Postcode Registered Office Address Page", () => {
     it("should load the office address page with English text", async () => {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -1,0 +1,7 @@
+import * as config from "../config/constants";
+import { LocalesService } from "@companieshouse/ch-node-utils";
+
+export const setLocalesEnabled = (bool: boolean) => {
+  jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
+  LocalesService.getInstance().enabled = bool;
+};


### PR DESCRIPTION
### JIRA link
NA


### Change description
Removing duplication of the setLocalesEnabled function used in the tests by importing it


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.