### PR TITLE
LP-451 Fixing Wave accessibility issue on Name page

### DIFF
--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -43,11 +43,6 @@
       <h1 class="govuk-heading-xl">{{ title }}</h1>
 
       <div class="govuk-form-group">
-        <h1 class="govuk-label-wrapper">
-          <label class="govuk-label govuk-label--l" for="partnership_name">
-            {{ whatIsName }}
-          </label>
-        </h1>
 
         {{ govukInput ({
           classes: "govuk-input--width-40",
@@ -55,12 +50,12 @@
           id: "partnership_name",
           name: "partnership_name",
           value: props.data.limitedPartnership.data.partnership_name,
-          fieldset: {
-            legend: {
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--xl"
-            }
+          label: {
+            text: whatIsName,
+            classes: "govuk-label--l",
+            isPageHeading: false
           },
+          
           hint: {
             text: i18n.namePage.whatIsNameHint
           },
@@ -83,14 +78,8 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="name_ending-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
-              {{ nameEnding }}
-            </h1>
-          </legend>
 
           {% include "pages/name/options-with-or-without-welsh.njk" %}
-
         </fieldset>
       </div>
 

--- a/src/views/pages/name/options-with-or-without-welsh.njk
+++ b/src/views/pages/name/options-with-or-without-welsh.njk
@@ -74,8 +74,9 @@
   value: props.data.limitedPartnership.data.name_ending,
   fieldset: {
     legend: {
+      text: nameEnding,
       isPageHeading: false,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-451


### Change description
Fixing an accessibility issue highlighted by the Wave plugin on the Name page.
Issue was related to legend text
Moved the text into the gouvuk components for both fields on the page to solve this.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.