### PR TITLE
LP-278 Matomo addess postcode lookup page

### DIFF
--- a/src/views/postcode-registered-office-address.njk
+++ b/src/views/postcode-registered-office-address.njk
@@ -65,14 +65,14 @@
           }) }}
 
           <p>
-            <a href="{{ props.currentUrl | replace(props.pageType, props.data.enterRegisteredOfficeAddressPageType) }}" class="govuk-body-m govuk-link" onclick="_paq.push(['trackEvent', 'Limited Partnerships registered addess', 'manual-page-link', 'enter-address-manually']);">{{ i18n.officeAddress.enterAddressManually }}</a>
+            <a href="{{ props.currentUrl | replace(props.pageType, props.data.enterRegisteredOfficeAddressPageType) }}" class="govuk-body-m govuk-link" data-event-id="enter-address-manually">{{ i18n.officeAddress.enterAddressManually }}</a>
           <p>
 
           {{ govukButton({
             text: i18n.officeAddress.findAddress,
             attributes: {
               "id": "submit",
-              "onclick": "_paq.push(['trackEvent', 'Limited Partnerships registered addess', 'find-addess', 'submit']);"
+              "onclick": "_paq.push(['trackEvent', 'Limited Partnerships registered office address', 'find-office-address', 'submit']);"
             }
           }) }}
       </div>

--- a/src/views/postcode-registered-office-address.njk
+++ b/src/views/postcode-registered-office-address.njk
@@ -65,13 +65,14 @@
           }) }}
 
           <p>
-            <a href="{{ props.currentUrl | replace(props.pageType, props.data.enterRegisteredOfficeAddressPageType) }}" class="govuk-body-m govuk-link" data-event-id="enter-address-manually">{{ i18n.officeAddress.enterAddressManually }}</a>
+            <a href="{{ props.currentUrl | replace(props.pageType, props.data.enterRegisteredOfficeAddressPageType) }}" class="govuk-body-m govuk-link" onclick="_paq.push(['trackEvent', 'Limited Partnerships registered addess', 'manual-page-link', 'enter-address-manually']);">{{ i18n.officeAddress.enterAddressManually }}</a>
           <p>
 
           {{ govukButton({
             text: i18n.officeAddress.findAddress,
             attributes: {
-              "id": "submit"
+              "id": "submit",
+              "onclick": "_paq.push(['trackEvent', 'Limited Partnerships registered addess', 'find-addess', 'submit']);"
             }
           }) }}
       </div>

--- a/src/views/postcode-registered-office-address.njk
+++ b/src/views/postcode-registered-office-address.njk
@@ -72,7 +72,7 @@
             text: i18n.officeAddress.findAddress,
             attributes: {
               "id": "submit",
-              "onclick": "_paq.push(['trackEvent', 'Limited Partnerships registered office address', 'find-office-address', 'submit']);"
+              "data-event-id": "find-address"
             }
           }) }}
       </div>


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-278


### Change description

Data event ids were present on the page for the AC2 manual link, this was not logging anything in Matomo so have altered this to run code on click similar to what we have for the submit button on other pages.

Updated the find button to include tracking also based on what we have for buttons on other pages. 

Not been able to fulfil AC5 (now removed) dues to complications in obtaining error message data dynamically so all we see in Matomo is "Submit" regardless; would propose a separate ticket to address error messages.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.