### PR TITLE
LP-221 fix validation messages on manual entry registered office address page

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -12,6 +12,43 @@
             }
         },
 
+        "enterAddress": {
+            "registeredOfficeAddress" : {
+                "title": "WELSH - What is the registered office address of the partnership?",
+                "titleHint1": "WELSH - We'll use this address to send official communications.",
+                "titleHint2": "WELSH - It must be a physical address in the jurisdiction where the partnership was formed. You cannot use a PO Box address.",
+                "titleHint3": "WELSH - It is not the principal place of business. You'll need to provide this later.",
+                "publicInformationTitle": "WELSH - What information we'll show on the public online register",
+                "publicInformationLine1": "WELSH - We'll show the registered office address on the public register."
+            },
+            "propertyNameOrNumber": "WELSH - Property name or number",
+            "propertyNameOrNumberHint": "WELSH - For example, 'The Mill', '116' or 'Flat 37a'",
+            "addressLine1": "WELSH - Address line 1",
+            "addressLine2": "WELSH - Address line 2 (optional)",
+            "townOrCity": "WELSH - Town or city",
+            "county": "WELSH - County (optional)",
+            "postcode": "WELSH - Postcode",
+            "country": "WELSH - Country",
+            "countrySelect": "WELSH - Select country",
+            "countryEngland": "WELSH - England",
+            "countryScotland": "WELSH - Scotland",
+            "countryWales": "WELSH - Wales",
+            "countryNorthernIreland": "WELSH - Northern Ireland",
+            "errorMessage": {
+                "nameOrNumberMissing": "WELSH - Enter a property name or number",
+                "nameOrNumberLength": "WELSH - Property name or number must be 50 characters or less",
+                "addressLine1Missing": "WELSH - Enter an address",
+                "addressLine1Length": "WELSH - Address line 1 must be 50 characters or less",
+                "addressLine2Length": "WELSH - Address line 2 must be 50 characters or less",
+                "townOrCityMissing": "WELSH - Enter a town or city",
+                "townOrCityLength": "WELSH - Town or city must be 50 characters or less",
+                "countyLength": "WELSH - County, state, province or region must be 50 characters or less",
+                "postcodeMissing": "WELSH - nter a postcode",
+                "postcodeLength": "WELSH - Postcode must be 15 characters or less",
+                "countryMissing": "WELSH - Select a country"
+            }
+        },
+
         "findPostcode": {
             "registeredOfficeAddress": {
 
@@ -81,28 +118,6 @@
             "publicRegister": "WELSH - It will not be shown on the public register."
         }
     },
-
-    "enterRegisteredOfficeAddressPage" : {
-        "title": "WELSH - What is the registered office address of the partnership?",
-        "titleHint1": "WELSH - We'll use this address to send official communications.",
-        "titleHint2": "WELSH - It must be a physical address in the jurisdiction where the partnership was formed. You cannot use a PO Box address.",
-        "titleHint3": "WELSH - It is not the principal place of business. You'll need to provide this later.",
-        "propertyNameOrNumber": "WELSH - Property name or number",
-        "propertyNameOrNumberHint": "WELSH - For example, 'The Mill', '116' or 'Flat 37a'",
-        "addressLine1": "WELSH - Address line 1",
-        "addressLine2": "WELSH - Address line 2 (optional)",
-        "townOrCity": "WELSH - Town or city",
-        "county": "WELSH - County (optional)",
-        "postcode": "WELSH - Postcode",
-        "country": "WELSH - Country",
-        "countrySelect": "WELSH - Select country",
-        "countryEngland": "WELSH - England",
-        "countryScotland": "WELSH - Scotland",
-        "countryWales": "WELSH - Wales",
-        "countryNorthernIreland": "WELSH - Northern Ireland",
-        "publicInformationTitle": "WELSH - What information we'll show on the public online register",
-        "publicInformationLine1": "WELSH - We'll show the registered office address on the public register."
-   },
 
     "errorPage" : {
         "title" : "WELSH - Sorry, the service is unavailable",

--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -34,7 +34,7 @@
             "countryScotland": "WELSH - Scotland",
             "countryWales": "WELSH - Wales",
             "countryNorthernIreland": "WELSH - Northern Ireland",
-            "errorMessage": {
+            "errorMessages": {
                 "nameOrNumberMissing": "WELSH - Enter a property name or number",
                 "nameOrNumberLength": "WELSH - Property name or number must be 50 characters or less",
                 "addressLine1Missing": "WELSH - Enter an address",
@@ -84,7 +84,8 @@
             "errorMessages": {
                 "jurisdictionEnglandAndWales": "WELSH - You must enter a postcode which is in England or Wales",
                 "jurisdictionNorthernIreland": "WELSH - You must enter a postcode which is in Northern Ireland",
-                "jurisdictionScotland": "WELSH - You must enter a postcode which is in Scotland"
+                "jurisdictionScotland": "WELSH - You must enter a postcode which is in Scotland",
+                "jurisdictionCountry": "WELSH - You must enter a country that matches your jurisdiction"
             }
         }
     },

--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -144,6 +144,12 @@
         "pageInformation": "WELSH - If the partnership has more than one general partner, you'll add them one at a time."
     },
 
+    "govUk" : {
+        "error" : {
+            "title" : "WELSH - There is a problem"
+        }
+    },
+
     "limitedPartnerChoicePage" : {
         "isPersonOrLegalEntity" : "WELSH - Is the limited partner a person or a legal entity?",
         "isPersonOrLegalEntityHint" : "WELSH - You can add more later.",

--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -45,7 +45,8 @@
                 "countyLength": "WELSH - County, state, province or region must be 50 characters or less",
                 "postcodeMissing": "WELSH - nter a postcode",
                 "postcodeLength": "WELSH - Postcode must be 15 characters or less",
-                "countryMissing": "WELSH - Select a country"
+                "countryMissing": "WELSH - Select a country",
+                "jurisdictionCountry": "WELSH - You must enter a country that matches your jurisdiction"
             }
         },
 
@@ -84,8 +85,7 @@
             "errorMessages": {
                 "jurisdictionEnglandAndWales": "WELSH - You must enter a postcode which is in England or Wales",
                 "jurisdictionNorthernIreland": "WELSH - You must enter a postcode which is in Northern Ireland",
-                "jurisdictionScotland": "WELSH - You must enter a postcode which is in Scotland",
-                "jurisdictionCountry": "WELSH - You must enter a country that matches your jurisdiction"
+                "jurisdictionScotland": "WELSH - You must enter a postcode which is in Scotland"
             }
         }
     },

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -45,7 +45,8 @@
                 "countyLength": "County, state, province or region must be 50 characters or less",
                 "postcodeMissing": "Enter a postcode",
                 "postcodeLength": "Postcode must be 15 characters or less",
-                "countryMissing": "Select a country"
+                "countryMissing": "Select a country",
+                "jurisdictionCountry": "You must enter a country that matches your jurisdiction"
             }
         },
 
@@ -84,8 +85,7 @@
             "errorMessages": {
                 "jurisdictionEnglandAndWales": "You must enter a postcode which is in England or Wales",
                 "jurisdictionNorthernIreland": "You must enter a postcode which is in Northern Ireland",
-                "jurisdictionScotland": "You must enter a postcode which is in Scotland",
-                "jurisdictionCountry": "You must enter a country that matches your jurisdiction"
+                "jurisdictionScotland": "You must enter a postcode which is in Scotland"
             }
         }
     },

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -12,6 +12,43 @@
             }
         },
 
+        "enterAddress": {
+            "registeredOfficeAddress" : {
+                "title": "What is the registered office address of the partnership?",
+                "titleHint1": "We'll use this address to send official communications.",
+                "titleHint2": "It must be a physical address in the jurisdiction where the partnership was formed. You cannot use a PO Box address.",
+                "titleHint3": "It is not the principal place of business. You'll need to provide this later.",
+                "publicInformationTitle": "What information we'll show on the public online register",
+                "publicInformationLine1": "We'll show the registered office address on the public register."
+            },
+            "propertyNameOrNumber": "Property name or number",
+            "propertyNameOrNumberHint": "For example, 'The Mill', '116' or 'Flat 37a'",
+            "addressLine1": "Address line 1",
+            "addressLine2": "Address line 2 (optional)",
+            "townOrCity": "Town or city",
+            "county": "County (optional)",
+            "postcode": "Postcode",
+            "country": "Country",
+            "countrySelect": "Select country",
+            "countryEngland": "England",
+            "countryScotland": "Scotland",
+            "countryWales": "Wales",
+            "countryNorthernIreland": "Northern Ireland",
+            "errorMessage": {
+                "nameOrNumberMissing": "Enter a property name or number",
+                "nameOrNumberLength": "Property name or number must be 50 characters or less",
+                "addressLine1Missing": "Enter an address",
+                "addressLine1Length": "Address line 1 must be 50 characters or less",
+                "addressLine2Length": "Address line 2 must be 50 characters or less",
+                "townOrCityMissing": "Enter a town or city",
+                "townOrCityLength": "Town or city must be 50 characters or less",
+                "countyLength": "County, state, province or region must be 50 characters or less",
+                "postcodeMissing": "Enter a postcode",
+                "postcodeLength": "Postcode must be 15 characters or less",
+                "countryMissing": "Select a country"
+            }
+        },
+
         "findPostcode": {
             "registeredOfficeAddress": {
 
@@ -81,41 +118,6 @@
             "publicRegister": "It will not be shown on the public register."
         }
     },
-
-    "enterRegisteredOfficeAddressPage" : {
-        "title": "What is the registered office address of the partnership?",
-        "titleHint1": "We'll use this address to send official communications.",
-        "titleHint2": "It must be a physical address in the jurisdiction where the partnership was formed. You cannot use a PO Box address.",
-        "titleHint3": "It is not the principal place of business. You'll need to provide this later.",
-        "propertyNameOrNumber": "Property name or number",
-        "propertyNameOrNumberHint": "For example, 'The Mill', '116' or 'Flat 37a'",
-        "addressLine1": "Address line 1",
-        "addressLine2": "Address line 2 (optional)",
-        "townOrCity": "Town or city",
-        "county": "County (optional)",
-        "postcode": "Postcode",
-        "country": "Country",
-        "countrySelect": "Select country",
-        "countryEngland": "England",
-        "countryScotland": "Scotland",
-        "countryWales": "Wales",
-        "countryNorthernIreland": "Northern Ireland",
-        "publicInformationTitle": "What information we'll show on the public online register",
-        "publicInformationLine1": "We'll show the registered office address on the public register.",
-        "errorMessage": {
-            "nameOrNumberMissing": "Enter a property name or number",
-            "nameOrNumberLength": "Property name or number must be 50 characters or less",
-            "addressLine1Missing": "Enter an address",
-            "addressLine1Length": "Address line 1 must be 50 characters or less",
-            "addressLine2Length": "Address line 2 must be 50 characters or less",
-            "townOrCityMissing": "Enter a town or city",
-            "townOrCityLength": "Town or city must be 50 characters or less",
-            "countyLength": "County, state, province or region must be 50 characters or less",
-            "postcodeMissing": "Enter a postcode",
-            "postcodeLength": "Postcode must be 15 characters or less",
-            "countryMissing": "Select a country"
-        }
-   },
 
     "errorPage" : {
         "title" : "Sorry, the service is unavailable",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -142,7 +142,13 @@
     "generalPartnersPage": {
         "title": "You now need to tell us about the general partners",
         "pageInformation": "If the partnership has more than one general partner, you'll add them one at a time."
-    }, 
+    },
+
+    "govUk" : {
+        "error" : {
+            "title" : "There is a problem"
+        }
+    },
     
     "limitedPartnerChoicePage" : {
         "isPersonOrLegalEntity" : "Is the limited partner a person or a legal entity?",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -34,7 +34,7 @@
             "countryScotland": "Scotland",
             "countryWales": "Wales",
             "countryNorthernIreland": "Northern Ireland",
-            "errorMessage": {
+            "errorMessages": {
                 "nameOrNumberMissing": "Enter a property name or number",
                 "nameOrNumberLength": "Property name or number must be 50 characters or less",
                 "addressLine1Missing": "Enter an address",
@@ -84,7 +84,8 @@
             "errorMessages": {
                 "jurisdictionEnglandAndWales": "You must enter a postcode which is in England or Wales",
                 "jurisdictionNorthernIreland": "You must enter a postcode which is in Northern Ireland",
-                "jurisdictionScotland": "You must enter a postcode which is in Scotland"
+                "jurisdictionScotland": "You must enter a postcode which is in Scotland",
+                "jurisdictionCountry": "You must enter a country that matches your jurisdiction"
             }
         }
     },

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -101,7 +101,20 @@
         "countryWales": "Wales",
         "countryNorthernIreland": "Northern Ireland",
         "publicInformationTitle": "What information we'll show on the public online register",
-        "publicInformationLine1": "We'll show the registered office address on the public register."
+        "publicInformationLine1": "We'll show the registered office address on the public register.",
+        "errorMessage": {
+            "nameOrNumberMissing": "Enter a property name or number",
+            "nameOrNumberLength": "Property name or number must be 50 characters or less",
+            "addressLine1Missing": "Enter an address",
+            "addressLine1Length": "Address line 1 must be 50 characters or less",
+            "addressLine2Length": "Address line 2 must be 50 characters or less",
+            "townOrCityMissing": "Enter a town or city",
+            "townOrCityLength": "Town or city must be 50 characters or less",
+            "countyLength": "County, state, province or region must be 50 characters or less",
+            "postcodeMissing": "Enter a postcode",
+            "postcodeLength": "Postcode must be 15 characters or less",
+            "countryMissing": "Select a country"
+        }
    },
 
     "errorPage" : {

--- a/src/application/service/AddressLookUpService.ts
+++ b/src/application/service/AddressLookUpService.ts
@@ -161,9 +161,9 @@ class AddressLookUpService {
     uiErrors: UIErrors
   ): boolean {
 
-    const isValid = (jurisdiction === Jurisdiction.SCOTLAND && country === "scotland")
-      || (jurisdiction === Jurisdiction.NORTHERN_IRELAND && country === "northern-ireland")
-      || (jurisdiction === Jurisdiction.ENGLAND_AND_WALES && (country === "england" || country === "wales"));
+    const isValid = (jurisdiction === Jurisdiction.SCOTLAND && country === "GB-SCT")
+      || (jurisdiction === Jurisdiction.NORTHERN_IRELAND && country === "GB-NIR")
+      || (jurisdiction === Jurisdiction.ENGLAND_AND_WALES && (country === "GB-ENG" || country === "GB-WLS"));
 
     if (!isValid) {
       this.setFieldError(

--- a/src/application/service/AddressLookUpService.ts
+++ b/src/application/service/AddressLookUpService.ts
@@ -156,7 +156,11 @@ class AddressLookUpService {
       (jurisdiction === Jurisdiction.ENGLAND_AND_WALES && (country === "GB-ENG" || country === "GB-WLS"));
 
     if (!isValid) {
-      this.setFieldError(uiErrors, "country", "You must enter a country that matches your jurisdiction");
+      this.setFieldError(
+        uiErrors,
+        "country",
+        this.i18n?.address?.findPostcode?.errorMessages?.jurisdictionCountry
+      );
     }
 
     return isValid;

--- a/src/application/service/AddressLookUpService.ts
+++ b/src/application/service/AddressLookUpService.ts
@@ -159,7 +159,7 @@ class AddressLookUpService {
       this.setFieldError(
         uiErrors,
         "country",
-        this.i18n?.address?.findPostcode?.errorMessages?.jurisdictionCountry
+        this.i18n?.address?.enterAddress?.errorMessages?.jurisdictionCountry
       );
     }
 

--- a/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
@@ -29,7 +29,7 @@ describe("Enter Registered Office Address Page", () => {
       const res = await request(app).get(URL + "?lang=en");
 
       expect(res.status).toBe(200);
-      testTranslations(res.text, enTranslationText.enterRegisteredOfficeAddressPage);
+      testTranslations(res.text, enTranslationText.address.enterAddress);
       expect(res.text).not.toContain("WELSH -");
     });
 
@@ -39,7 +39,7 @@ describe("Enter Registered Office Address Page", () => {
       const res = await request(app).get(URL + "?lang=cy");
 
       expect(res.status).toBe(200);
-      testTranslations(res.text, cyTranslationText.enterRegisteredOfficeAddressPage);
+      testTranslations(res.text, cyTranslationText.address.enterAddress);
     });
   });
 

--- a/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
@@ -97,6 +97,7 @@ describe("Enter Registered Office Address Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
+      expect(res.text).toContain(enTranslationText.govUk.error.title);
     });
 
     it("should return a Welsh validation error when jurisdiction of Scotland does not match country", async () => {
@@ -117,6 +118,7 @@ describe("Enter Registered Office Address Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(cyTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
+      expect(res.text).toContain(cyTranslationText.govUk.error.title);
     });
 
     it("should return a validation error when jurisdiction of Northern Ireland does not match country", async () => {
@@ -135,6 +137,7 @@ describe("Enter Registered Office Address Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
+      expect(res.text).toContain(enTranslationText.govUk.error.title);
     });
 
     it("should return a validation error when jurisdiction of England and Wales does not match country", async () => {
@@ -153,6 +156,7 @@ describe("Enter Registered Office Address Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
+      expect(res.text).toContain(enTranslationText.govUk.error.title);
     });
   });
 

--- a/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
@@ -55,7 +55,7 @@ describe("Enter Registered Office Address Page", () => {
 
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterRegisteredOfficeAddress,
-        country: "wales"
+        country: "GB-WLS"
       });
 
       const redirectUrl = getUrl(CONFIRM_REGISTERED_OFFICE_ADDRESS_URL);
@@ -74,7 +74,7 @@ describe("Enter Registered Office Address Page", () => {
 
       const res = await request(app).post(URL).send({
         pageType: "Invalid page type",
-        country: "scotland"
+        country: "GB-SCT"
       });
 
       expect(res.status).toBe(500);

--- a/src/views/enter-registered-office-address.njk
+++ b/src/views/enter-registered-office-address.njk
@@ -15,10 +15,10 @@
 
 {% set pageTitle = i18n.address.enterAddress.registeredOfficeAddress.title %}
 
-{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.nameOrNumberMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.nameOrNumberLength | escape + "');" %}
-{% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.addressLine1Missing | escape + "', '" + i18n.address.enterAddress.errorMessage.addressLine1Length | escape + "');" %}
-{% set validateTownOrCity = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.townOrCityMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.townOrCityLength | escape + "');" %}
-{% set validatePostcode = "validateInput(this, 15, '" + i18n.address.enterAddress.errorMessage.postcodeMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.postcodeLength | escape + "');" %}
+{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.nameOrNumberMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.nameOrNumberLength | escape + "');" %}
+{% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.addressLine1Missing | escape + "', '" + i18n.address.enterAddress.errorMessages.addressLine1Length | escape + "');" %}
+{% set validateTownOrCity = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.townOrCityMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.townOrCityLength | escape + "');" %}
+{% set validatePostcode = "validateInput(this, 15, '" + i18n.address.enterAddress.errorMessages.postcodeMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.postcodeLength | escape + "');" %}
 
 {% block content %}
 
@@ -89,7 +89,7 @@
               name: "address_line_2",
               value: registeredOfficeAddress.address_line_2,
               attributes : {  
-                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessage.addressLine2Length | escape + "');",
+                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessages.addressLine2Length | escape + "');",
                 "data-event-id": "address-line-2"
               }
             }) }}
@@ -119,7 +119,7 @@
               name: "region",
               value: registeredOfficeAddress.region,
               attributes : {
-                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessage.countyLength | escape + "');",
+                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessages.countyLength | escape + "');",
                 "data-event-id": "county"
               }
             }) }}
@@ -156,7 +156,7 @@
               },
               attributes : {
                 required: "true",
-                oninvalid: "this.setCustomValidity('" + i18n.address.enterAddress.errorMessage.countryMissing + "');",
+                oninvalid: "this.setCustomValidity('" + i18n.address.enterAddress.errorMessages.countryMissing + "');",
                 oninput: "this.setCustomValidity('');",
                 "data-event-id": "country"
               },

--- a/src/views/enter-registered-office-address.njk
+++ b/src/views/enter-registered-office-address.njk
@@ -1,5 +1,7 @@
 {% extends "layout.njk" %}
 
+{% import 'includes/macros.njk' as macros %}
+
 {% set registeredOfficeKey = "registration_registered_office_address" %}
 {% if props.data.address %}
   {% set registeredOfficeAddress = props.data.address %}
@@ -12,6 +14,11 @@
 {% endif %}
 
 {% set pageTitle = i18n.enterRegisteredOfficeAddressPage.title %}
+
+{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.nameOrNumberMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.nameOrNumberLength | escape + "');" %}
+{% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine1Missing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine1Length | escape + "');" %}
+{% set validateTownOrCity = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.townOrCityMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.townOrCityLength | escape + "');" %}
+{% set validatePostcode = "validateInput(this, 15, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.postcodeMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.postcodeLength | escape + "');" %}
 
 {% block content %}
 
@@ -53,7 +60,8 @@
               value: registeredOfficeAddress.premises,
               attributes : {  
                 required : true,
-                maxLength: 50,
+                oninvalid: validateNameOrNumber,
+                oninput: validateNameOrNumber,
                 "data-event-id": "property-name-or-number"
               }
             }) }}
@@ -67,7 +75,8 @@
               value: registeredOfficeAddress.address_line_1,
               attributes : {
                 required : true,
-                maxLength: 50,
+                oninvalid: validateAddressLine1,
+                oninput: validateAddressLine1,
                 "data-event-id": "address-line-1"
               }
             }) }}
@@ -79,8 +88,8 @@
               id: "address_line_2",
               name: "address_line_2",
               value: registeredOfficeAddress.address_line_2,
-              attributes : {
-                maxLength: 50,
+              attributes : {  
+                oninput: "validateLength(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine2Length | escape + "');",
                 "data-event-id": "address-line-2"
               }
             }) }}
@@ -95,7 +104,8 @@
               value: registeredOfficeAddress.locality,
               attributes : {
                 required : true,
-                maxLength: 50,
+                oninvalid: validateTownOrCity,
+                oninput: validateTownOrCity,
                 "data-event-id": "town-or-city"
               }
             }) }}
@@ -109,7 +119,7 @@
               name: "region",
               value: registeredOfficeAddress.region,
               attributes : {
-                maxLength: 50,
+                oninput: "validateLength(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.countyLength | escape + "');",
                 "data-event-id": "county"
               }
             }) }}
@@ -124,7 +134,8 @@
               value: registeredOfficeAddress.postal_code,
               attributes : {
                 required : true,
-                maxLength: 15,
+                oninvalid: validatePostcode,
+                oninput: validatePostcode,
                 "data-event-id": "postcode"
               }
             }) }}
@@ -145,6 +156,8 @@
               },
               attributes : {
                 required: "true",
+                oninvalid: "this.setCustomValidity('" + i18n.enterRegisteredOfficeAddressPage.errorMessage.countryMissing + "');",
+                oninput: "this.setCustomValidity('');",
                 "data-event-id": "country"
               },
               items: [
@@ -165,7 +178,7 @@
                   text: i18n.enterRegisteredOfficeAddressPage.countryWales
                 },
                 {
-                  value: "northern-ireland",
+                  value: "northern ireland",
                   text: i18n.enterRegisteredOfficeAddressPage.countryNorthernIreland
                 }
               ]
@@ -183,5 +196,23 @@
       </form>
     </div>
   </div>
-  
+  <script>
+    function validateInput(input, maxLength, missingMessage, lengthMessage) {
+      if (!input.value) {
+        input.setCustomValidity(missingMessage);
+      } else if (input.value.length > maxLength) {
+        input.setCustomValidity(lengthMessage);
+      } else {
+        input.setCustomValidity('');
+      }
+    }
+
+    function validateLength(input, maxLength, lengthMessage) {
+      if (input.value.length > maxLength) {
+        input.setCustomValidity(lengthMessage);
+      } else {
+        input.setCustomValidity('');
+      }
+    }
+</script>
 {% endblock %}

--- a/src/views/enter-registered-office-address.njk
+++ b/src/views/enter-registered-office-address.njk
@@ -13,12 +13,12 @@
   {% set registeredOfficeAddress = {} %}
 {% endif %}
 
-{% set pageTitle = i18n.enterRegisteredOfficeAddressPage.title %}
+{% set pageTitle = i18n.address.enterAddress.registeredOfficeAddress.title %}
 
-{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.nameOrNumberMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.nameOrNumberLength | escape + "');" %}
-{% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine1Missing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine1Length | escape + "');" %}
-{% set validateTownOrCity = "validateInput(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.townOrCityMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.townOrCityLength | escape + "');" %}
-{% set validatePostcode = "validateInput(this, 15, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.postcodeMissing | escape + "', '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.postcodeLength | escape + "');" %}
+{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.nameOrNumberMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.nameOrNumberLength | escape + "');" %}
+{% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.addressLine1Missing | escape + "', '" + i18n.address.enterAddress.errorMessage.addressLine1Length | escape + "');" %}
+{% set validateTownOrCity = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessage.townOrCityMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.townOrCityLength | escape + "');" %}
+{% set validatePostcode = "validateInput(this, 15, '" + i18n.address.enterAddress.errorMessage.postcodeMissing | escape + "', '" + i18n.address.enterAddress.errorMessage.postcodeLength | escape + "');" %}
 
 {% block content %}
 
@@ -37,23 +37,23 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-heading-xl">
-                {{ i18n.enterRegisteredOfficeAddressPage.title }}
+                {{ i18n.address.enterAddress.registeredOfficeAddress.title }}
               </h1>
             </legend>
 
-            <p class="govuk-hint">{{ i18n.enterRegisteredOfficeAddressPage.titleHint1 }}</p>
-            <p class="govuk-hint">{{ i18n.enterRegisteredOfficeAddressPage.titleHint2 }}</p>
-            <p class="govuk-hint">{{ i18n.enterRegisteredOfficeAddressPage.titleHint3 }}</p>
+            <p class="govuk-hint">{{ i18n.address.enterAddress.registeredOfficeAddress.titleHint1 }}</p>
+            <p class="govuk-hint">{{ i18n.address.enterAddress.registeredOfficeAddress.titleHint2 }}</p>
+            <p class="govuk-hint">{{ i18n.address.enterAddress.registeredOfficeAddress.titleHint3 }}</p>
             
             <br>
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.propertyNameOrNumber,
+                text: i18n.address.enterAddress.propertyNameOrNumber,
                 classes: "govuk-!-margin-top-5"
               },
               hint: {
-                text: i18n.enterRegisteredOfficeAddressPage.propertyNameOrNumberHint
+                text: i18n.address.enterAddress.propertyNameOrNumberHint
               },
               id: "premises",
               name: "premises",
@@ -68,7 +68,7 @@
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.addressLine1
+                text: i18n.address.enterAddress.addressLine1
               },
               id: "address_line_1",
               name: "address_line_1",
@@ -83,20 +83,20 @@
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.addressLine2
+                text: i18n.address.enterAddress.addressLine2
               },
               id: "address_line_2",
               name: "address_line_2",
               value: registeredOfficeAddress.address_line_2,
               attributes : {  
-                oninput: "validateLength(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.addressLine2Length | escape + "');",
+                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessage.addressLine2Length | escape + "');",
                 "data-event-id": "address-line-2"
               }
             }) }}
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.townOrCity
+                text: i18n.address.enterAddress.townOrCity
               },
               classes: "govuk-!-width-two-thirds",
               id: "locality",
@@ -112,21 +112,21 @@
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.county
+                text: i18n.address.enterAddress.county
               },
               classes: "govuk-!-width-two-thirds",
               id: "region",
               name: "region",
               value: registeredOfficeAddress.region,
               attributes : {
-                oninput: "validateLength(this, 50, '" + i18n.enterRegisteredOfficeAddressPage.errorMessage.countyLength | escape + "');",
+                oninput: "validateLength(this, 50, '" + i18n.address.enterAddress.errorMessage.countyLength | escape + "');",
                 "data-event-id": "county"
               }
             }) }}
 
             {{ govukInput({
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.postcode
+                text: i18n.address.enterAddress.postcode
               },
               classes: "govuk-input--width-10",
               id: "postal_code",
@@ -145,7 +145,7 @@
               name: "country",
               value: registeredOfficeAddress.country,
               label: {
-                text: i18n.enterRegisteredOfficeAddressPage.country
+                text: i18n.address.enterAddress.country
               },
               fieldset: {
                 legend: {
@@ -156,38 +156,38 @@
               },
               attributes : {
                 required: "true",
-                oninvalid: "this.setCustomValidity('" + i18n.enterRegisteredOfficeAddressPage.errorMessage.countryMissing + "');",
+                oninvalid: "this.setCustomValidity('" + i18n.address.enterAddress.errorMessage.countryMissing + "');",
                 oninput: "this.setCustomValidity('');",
                 "data-event-id": "country"
               },
               items: [
                 {
                   value: "",
-                  text: i18n.enterRegisteredOfficeAddressPage.countrySelect
+                  text: i18n.address.enterAddress.countrySelect
                 },
                 {
                   value: "england",
-                  text: i18n.enterRegisteredOfficeAddressPage.countryEngland
+                  text: i18n.address.enterAddress.countryEngland
                 },
                 {
                   value: "scotland",
-                  text: i18n.enterRegisteredOfficeAddressPage.countryScotland
+                  text: i18n.address.enterAddress.countryScotland
                 },
                 {
                   value: "wales",
-                  text: i18n.enterRegisteredOfficeAddressPage.countryWales
+                  text: i18n.address.enterAddress.countryWales
                 },
                 {
                   value: "northern ireland",
-                  text: i18n.enterRegisteredOfficeAddressPage.countryNorthernIreland
+                  text: i18n.address.enterAddress.countryNorthernIreland
                 }
               ]
             }) }}
           </fieldset>
 
           {{ govukInsetText({
-            html: "<h2 class='govuk-heading-m'>" + i18n.enterRegisteredOfficeAddressPage.publicInformationTitle | escape + "</h2>
-              <p>" + i18n.enterRegisteredOfficeAddressPage.publicInformationLine1 | escape + "</p>"
+            html: "<h2 class='govuk-heading-m'>" + i18n.address.enterAddress.registeredOfficeAddress.publicInformationTitle | escape + "</h2>
+              <p>" + i18n.address.enterAddress.registeredOfficeAddress.publicInformationLine1 | escape + "</p>"
           }) }}
 
           {% include "includes/save-and-continue-button.njk" %}

--- a/src/views/enter-registered-office-address.njk
+++ b/src/views/enter-registered-office-address.njk
@@ -166,19 +166,19 @@
                   text: i18n.address.enterAddress.countrySelect
                 },
                 {
-                  value: "england",
+                  value: "GB-ENG",
                   text: i18n.address.enterAddress.countryEngland
                 },
                 {
-                  value: "scotland",
+                  value: "GB-SCT",
                   text: i18n.address.enterAddress.countryScotland
                 },
                 {
-                  value: "wales",
+                  value: "GB-WLS",
                   text: i18n.address.enterAddress.countryWales
                 },
                 {
-                  value: "northern ireland",
+                  value: "GB-NIR",
                   text: i18n.address.enterAddress.countryNorthernIreland
                 }
               ]
@@ -196,23 +196,7 @@
       </form>
     </div>
   </div>
-  <script>
-    function validateInput(input, maxLength, missingMessage, lengthMessage) {
-      if (!input.value) {
-        input.setCustomValidity(missingMessage);
-      } else if (input.value.length > maxLength) {
-        input.setCustomValidity(lengthMessage);
-      } else {
-        input.setCustomValidity('');
-      }
-    }
 
-    function validateLength(input, maxLength, lengthMessage) {
-      if (input.value.length > maxLength) {
-        input.setCustomValidity(lengthMessage);
-      } else {
-        input.setCustomValidity('');
-      }
-    }
-</script>
+  {% include "includes/validators.njk" %}
+
 {% endblock %}

--- a/src/views/includes/errors.njk
+++ b/src/views/includes/errors.njk
@@ -1,6 +1,6 @@
 {% if props.errors and props.errors.errorList.length > 0 %}
   {{ govukErrorSummary({
-    titleText: "There is a problem",
+    titleText: i18n.govUk.error.title,
     errorList: props.errors.errorList,
     attributes: {
       "tabindex": "0"

--- a/src/views/includes/validators.njk
+++ b/src/views/includes/validators.njk
@@ -1,0 +1,19 @@
+ <script>
+    function validateInput(input, maxLength, missingMessage, lengthMessage) {
+      if (!input.value) {
+        input.setCustomValidity(missingMessage);
+      } else if (input.value.length > maxLength) {
+        input.setCustomValidity(lengthMessage);
+      } else {
+        input.setCustomValidity('');
+      }
+    }
+
+    function validateLength(input, maxLength, lengthMessage) {
+      if (input.value.length > maxLength) {
+        input.setCustomValidity(lengthMessage);
+      } else {
+        input.setCustomValidity('');
+      }
+    }
+</script>


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-221


### Change description
Add js validation messages for the manual address entry page
Change the country select option to use GB- values
Refactored translations for the manual address entry page 


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.