### PR TITLE
LP-530 Add second nationality to 'Add a general partner (person)' page

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -14,6 +14,10 @@
         "dateOfBirth" : "WELSH - Date of birth",
         "dateOfBirthHint" : "WELSH - For example, 27 3 2000",
         "nationality" : "WELSH - What is their nationality?",
+        "nationalitySelectPrompt": "WELSH - Select a nationality",
+        "secondNationality" : "WELSH - What is their second nationality (if relevant)?",
+        "secondNationalitySelectPrompt": "WELSH - Select a second nationality",
+        "secondNationalityHint" : "WELSH - Dual citizenship (also known as dual nationality) is allowed in some countries. This means you can be a citizen of your own country and another country.",
         "disqualificationStatement" : "WELSH - I confirm the general partner is not disqualified under the directors disqualification legislation.",
         "disqualificationStatementLegend" : "WELSH - General partner - person - disqualification statement",
         "publicRegisterTitle": "WELSH - What information we'll show on the public register",
@@ -320,7 +324,6 @@
     },
 
     "nationalities" : {
-      "selectOne" : "WELSH - Select a nationality",
       "afghan" : "WELSH - Afghan",
       "albanian" : "WELSH - Albanian",
       "algerian" : "WELSH - Algerian",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -14,6 +14,10 @@
         "dateOfBirth" : "Date of birth",
         "dateOfBirthHint" : "For example, 27 3 2000",
         "nationality" : "What is their nationality?",
+        "nationalitySelectPrompt": "Select a nationality",
+        "secondNationality" : "What is their second nationality (if relevant)?",
+        "secondNationalitySelectPrompt": "Select a second nationality",
+        "secondNationalityHint" : "Dual citizenship (also known as dual nationality) is allowed in some countries. This means you can be a citizen of your own country and another country.",
         "disqualificationStatement" : "I confirm the general partner is not disqualified under the directors disqualification legislation.",
         "disqualificationStatementLegend" : "General partner - person - disqualification statement",
         "publicRegisterTitle": "What information we'll show on the public register",
@@ -320,7 +324,6 @@
     },
 
     "nationalities" : {
-      "selectOne" : "Select a nationality",
       "afghan" : "Afghan",
       "albanian" : "Albanian",
       "algerian" : "Algerian",

--- a/src/views/add-general-partner-person.njk
+++ b/src/views/add-general-partner-person.njk
@@ -157,15 +157,20 @@
         }) }}
 
         {% set nationalityField = props.data.generalPartner.data.nationality1 %}
-        {% set nationalityText = i18n.addGeneralPartnerPersonPage.nationality %}
+        {% set nationalityFieldSelectPrompt = i18n.addGeneralPartnerPersonPage.nationalitySelectPrompt %}
+        {% set nationalityFieldRequired = "true" %}
+        {% set nationalityFieldText = i18n.addGeneralPartnerPersonPage.nationality %}
+        {% set nationalityFieldHintText = "" %}
+        {% set nationalityFieldNameId = "nationality1" %}
         {% include "includes/nationalities.njk" %}
 
-        <!-- TODO Placeholder mark-up - correct implementation for second nationality is covered by LP-530 -->
-        <p class="govuk-!-margin-bottom-8">
-          <a href="#" id="second-nationality-link" class="govuk-link govuk-link--no-visited-state hidden">
-            Add a second nationality
-          </a>
-        </p>
+        {% set nationalityField = props.data.generalPartner.data.nationality2 %}
+        {% set nationalityFieldSelectPrompt = i18n.addGeneralPartnerPersonPage.secondNationalitySelectPrompt %}
+        {% set nationalityFieldRequired = "false" %}
+        {% set nationalityFieldText = i18n.addGeneralPartnerPersonPage.secondNationality %}
+        {% set nationalityFieldHintText = i18n.addGeneralPartnerPersonPage.secondNationalityHint  %}
+        {% set nationalityFieldNameId = "nationality2" %}
+        {% include "includes/nationalities.njk" %}
 
         {{ govukCheckboxes({
           name: "not_disqualified_statement_checked",

--- a/src/views/includes/nationalities.njk
+++ b/src/views/includes/nationalities.njk
@@ -1,5 +1,5 @@
 {% set NATIONALITIES = [
-  { value: '', text: i18n.nationalities.selectOne },
+  { value: '', text: nationalityFieldSelectPrompt },
   { value: 'Afghan', text: i18n.nationalities.afghan, selected: nationalityField === 'Afghan' },
   { value: 'Albanian', text: i18n.nationalities.albanian, selected: nationalityField === 'Albanian' },
   { value: 'Algerian', text: i18n.nationalities.algerian, selected: nationalityField === 'Algerian' },
@@ -227,16 +227,22 @@
   { value: 'Zimbabwean', text: i18n.nationalities.zimbabwean, selected: nationalityField === 'Zimbabwean' }
 ] %}
 
+{% if nationalityFieldRequired == 'true' %}
+  {% set attributes = {required : "true"} %}
+{% endif %}
+
 {{ govukSelect({
-  id: "nationality1",
-  name: "nationality1",
+  errorMessage: props.errors[nationalityFieldNameId] if props.errors,
+  id: nationalityFieldNameId,
+  name: nationalityFieldNameId,
   label: {
-    text: nationalityText,
+    text: nationalityFieldText,
     classes: "govuk-label govuk-label--m",
     isPageHeading: false
   },
-  attributes : {
-    required: "true"
+  attributes : attributes,
+  hint: {
+    text: nationalityFieldHintText
   },
   items: NATIONALITIES
 }) }}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-530

### Change description

* Nationalties drop-down made more configurable
* Second nationality now displays on screen
* New translation texts added

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.