### PR TITLE
LP-530 Ensure check-box still ticked after API error

### DIFF
--- a/src/views/add-general-partner-person.njk
+++ b/src/views/add-general-partner-person.njk
@@ -173,11 +173,15 @@
         {% include "includes/nationalities.njk" %}
 
         {{ govukCheckboxes({
+          id: "not_disqualified_statement_checked",
           name: "not_disqualified_statement_checked",
+          value: props.data.generalPartner.data.not_disqualified_statement_checked,
+          errorMessage: props.errors.not_disqualified_statement_checked if props.errors,
           classes: "govuk-!-margin-top-6",
           fieldset: {
             legend: {
               text: i18n.addGeneralPartnerPersonPage.disqualificationStatementLegend,
+              isPageHeading: false,
               classes: "govuk-visually-hidden"
             }
           },
@@ -185,6 +189,7 @@
             {
               value: "true",
               text: i18n.addGeneralPartnerPersonPage.disqualificationStatement,
+              checked: props.data.generalPartner.data.not_disqualified_statement_checked,
               attributes: {
                 required: true
               }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-530

### Change description

* Missing attributes added to the Gov checkbox definition to ensure correct behaviour
* Also added the missing 'isPageHeading' attribute

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.