### PR TITLE
LP-517 Allow regex to tolerate leading and trailing spaces

### DIFF
--- a/src/views/company-number.njk
+++ b/src/views/company-number.njk
@@ -26,7 +26,7 @@
                 required: true,
                 "data-event-id": "company-number-transition"
             },
-            pattern: "^(LP|NL|SL)[0-9]{6}$",
+            pattern: "^\\s*(LP|NL|SL)[0-9]{6}\\s*$",
             errorMessage: props.errors.company_number if props.errors,
             value: props.data.company_number
           }) }}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-517


### Change description
For the transitions company number page

Updated regex in the nunjucks template to tolerate leading and trailing whitespaces.
Given that the template validates immediately as soon as the user enters the value, there isn't time to strip the spaces. This would be better as the subsequent lookup will reject any number that has a leading space.

You can add '-' for variables but not sure where it would go for values.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.