### PR TITLE
LP-637 Make name page update existing submission if IDs present

### DIFF
--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -204,6 +204,8 @@ describe("Name Page", () => {
         [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.whichType}`]: PartnershipType.LP
       });
 
+      expect(appDevDependencies.limitedPartnershipGateway.limitedPartnerships.length).toEqual(0);
+
       const res = await request(app).post(NAME_URL).send({
         pageType: RegistrationPageType.name,
         partnership_name: "Test Limited Partnership",
@@ -217,6 +219,7 @@ describe("Name Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {}
       });
+      expect(appDevDependencies.limitedPartnershipGateway.limitedPartnerships.length).toEqual(1);
     });
 
     it("should update the submission if already exist", async () => {
@@ -226,6 +229,8 @@ describe("Name Page", () => {
         .build();
 
       appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      expect(appDevDependencies.limitedPartnershipGateway.limitedPartnerships.length).toEqual(1);
 
       const URL = getUrl(NAME_WITH_IDS_URL);
 
@@ -238,6 +243,7 @@ describe("Name Page", () => {
 
       expect(res.status).toBe(302);
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+      expect(appDevDependencies.limitedPartnershipGateway.limitedPartnerships.length).toEqual(1);
     });
 
     it("should return validation errors", async () => {

--- a/src/views/name.njk
+++ b/src/views/name.njk
@@ -34,7 +34,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form class="form" action={{ props.currentUrl }} method="post">
+    <form class="form" method="post">
       <input type="hidden" name="pageType" value={{ props.pageType }}>
       <input type="hidden" name="partnership_type" value={{ partnershipType }}>
       


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-637


### Change description
If Ids are present in the URL then update submission name and don't create new transaction/submission
The form was always posting to props.currentUrl which was limited-partnerships/name, so removed the form action so it posts using the browser url which will include the ids if they are present.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.