### PR TITLE
Lp 554 confirm general partner usual residential address

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -94,8 +94,9 @@
                 "publicRegisterLine1": "WELSH - We'll show the principal place of business address on the public register."
             },
             "usualResidentialAddress": {
-                "title": "WELSH - Confirm the correspondence address of the general partner",
-                "addressLinkHidden": "WELSH - usual residential address"
+                "title": "WELSH - Confirm the general partner's usual residential address",
+                "addressLinkHidden": "WELSH - usual residential address",
+                "publicRegisterLine1": "WELSH - We will not show the general partner's usual residential address."
             }
         },
         

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -94,8 +94,9 @@
                 "publicRegisterLine1": "We'll show the principal place of business address on the public register."
             },
             "usualResidentialAddress": {
-                "title": "Confirm the correspondence address of the general partner",
-                "addressLinkHidden": "usual residential address"
+                "title": "Confirm the general partner's usual residential address",
+                "addressLinkHidden": "usual residential address",
+                "publicRegisterLine1": "We will not show the general partner's usual residential address."
             }
         },
         

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -372,9 +372,9 @@ class AddressLookUpController extends AbstractController {
 
     if (pageType === AddressLookUpPageType.confirmRegisteredOfficeAddress) {
       data = { registered_office_address: address };
-    } else if (AddressLookUpPageType.confirmPrincipalPlaceOfBusinessAddress) {
+    } else if (pageType === AddressLookUpPageType.confirmPrincipalPlaceOfBusinessAddress) {
       data = { principal_place_of_business_address: address };
-    } else if (AddressLookUpPageType.confirmGeneralPartnerUsualResidentialAddress) {
+    } else if (pageType === AddressLookUpPageType.confirmGeneralPartnerUsualResidentialAddress) {
       data = { usual_residential_address: address };
     }
 

--- a/src/views/confirm-general-partner-usual-residential-address.njk
+++ b/src/views/confirm-general-partner-usual-residential-address.njk
@@ -4,7 +4,7 @@
 {% set publicRegisterLine = i18n.address.confirm.usualResidentialAddress.publicRegisterLine1 %}
 {% set addressLinkHidden = i18n.address.confirm.usualResidentialAddress.addressLinkHidden %}
 {% set cacheKey = "usual_residential_address" %}
-{% set data = props.data.limitedPartnership.data.usual_residential_address %}
+{% set data = props.data.generalPartner.data.usual_residential_address %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/pages/address/confirm-address-form.njk
+++ b/src/views/pages/address/confirm-address-form.njk
@@ -33,8 +33,10 @@
             {{ macros.capitalizeEachWord(address.region) }}
             <br>
         {% endif %}
-        {{ address.postal_code | upper }}
+        {% if address.postal_code %}
+            {{ address.postal_code | upper }}
             <br>
+        {% endif %}
         {{ macros.mapCountry(address.country) }}
             <br>
         </p>


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-554


### Change description
Fixed function in addressLookUp controller to correctly set data for general partner confirm page.
Changed translations to display correct text on page
Changed confirm general partner page template to correctly set data if already present.
bug fix for post-code missing leaving a blank space

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.