### PR TITLE
LP-639 General partner enter pricipal office - fix page text

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -122,7 +122,7 @@
             },
             "principalOfficeAddress": {
                 "title": "WELSH - What is the general partner's principal office address?",
-                "publicInformationLine1": "WELSH - We will not show the general partner' principal office address on the public register",
+                "publicInformationLine1": "WELSH - We'll show the general partner's principal office address on the public register.",
                 "postcodeOptional": "WELSH - Postcode (optional)"
             },
             "propertyNameOrNumber": "WELSH - Property name or number",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -121,7 +121,7 @@
             },
             "principalOfficeAddress": {
                 "title": "What is the general partner's principal office address?",
-                "publicInformationLine1": "We will not show the general partner's principal office address on the public register",
+                "publicInformationLine1": "We'll show the general partner's principal office address on the public register.",
                 "postcodeOptional": "Postcode (optional)"
             },
             "propertyNameOrNumber": "Property name or number",
@@ -140,7 +140,7 @@
             "publicInformationTitle": "What information we'll show on the public register",
             "errorMessages": {
                 "nameOrNumberMissing": "Enter a property name or number",
-                "nameOrNumberLength": "Property name or number must be 50 characters or less",
+                "nameOrNumberLength": "Property name or number must be 200 characters or less",
                 "addressLine1Missing": "Enter an address",
                 "addressLine1Length": "Address line 1 must be 50 characters or less",
                 "addressLine2Length": "Address line 2 must be 50 characters or less",

--- a/src/views/pages/address/enter-address-fields.njk
+++ b/src/views/pages/address/enter-address-fields.njk
@@ -1,6 +1,6 @@
 {% import 'includes/macros.njk' as macros %}
 
-{% set validateNameOrNumber = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.nameOrNumberMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.nameOrNumberLength | escape + "');" %}
+{% set validateNameOrNumber = "validateInput(this, 200, '" + i18n.address.enterAddress.errorMessages.nameOrNumberMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.nameOrNumberLength | escape + "');" %}
 {% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.addressLine1Missing | escape + "', '" + i18n.address.enterAddress.errorMessages.addressLine1Length | escape + "');" %}
 {% set validateTownOrCity = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.townOrCityMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.townOrCityLength | escape + "');" %}
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-639


### Change description

Fixed errors highlighted from testing:

- Prototype and Mural indicate that the info at the bottom should read:
"We'll show the general partner's principal office address on the public register."
- Welsh is missing the s after the apostrophe
-  name number should have a max on 200 according to the description - this meant fixing the common template.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.