### PR TITLE
LP-732 Control presence of jurisdiction change link

### DIFF
--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -80,7 +80,8 @@
                 partnershipNameChangeText,
                 "change-jurisdiction-button"
               ) ]
-            }
+            } if props.data.limitedPartnership.data.partnership_type === "LP"
+                or props.data.limitedPartnership.data.partnership_type === "PFLP"
           },
           {
             key: {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-732

### Change description

* Change link for jursidiction now only shown on the 'check your answers' page if a non Scottish Partnership is being created
* Tests added to check presence of the link

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.