### PR TITLE
LP-667 Don't lose name on jurisdiction validation

### DIFF
--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -224,9 +224,14 @@ class AddressLookUpController extends AbstractController {
           : this.addressService.isValidJurisdictionAndCountry(limitedPartnership?.data?.jurisdiction ?? "", country);
 
         if (errors?.errors) {
+          const cacheById = this.cacheService.getDataFromCacheById(request.signedCookies, ids.transactionId);
           response.render(
             super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, { address }, errors)
+            super.makeProps(
+              pageRouting,
+              { address, limitedPartnership, cache: { ...cacheById } },
+              errors
+            )
           );
 
           return;

--- a/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/enter-registered-office-address.test.ts
@@ -100,6 +100,7 @@ describe("Enter Registered Office Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartnership.data?.partnership_name?.toUpperCase());
     });
 
     it("should return a Welsh validation error when jurisdiction of Scotland does not match country", async () => {
@@ -119,6 +120,7 @@ describe("Enter Registered Office Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(cyTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
       expect(res.text).toContain(cyTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartnership.data?.partnership_name?.toUpperCase());
     });
 
     it("should return a validation error when jurisdiction of Northern Ireland does not match country", async () => {
@@ -136,6 +138,7 @@ describe("Enter Registered Office Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartnership.data?.partnership_name?.toUpperCase());
     });
 
     it("should return a validation error when jurisdiction of England and Wales does not match country", async () => {
@@ -153,6 +156,7 @@ describe("Enter Registered Office Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.jurisdictionCountry);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartnership.data?.partnership_name?.toUpperCase());
     });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-667


### Change description
Make sure the partnership name is still on the page when we get a jurisdiction validation error


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.