### PR TITLE
LP-693 Show GP Name when postcode address error fires

### DIFF
--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -126,9 +126,23 @@ class AddressLookUpController extends AbstractController {
         );
 
         if (errors?.errors) {
+          const isGeneralPartnerAddress =
+            pageType === AddressLookUpPageType.postcodeGeneralPartnerUsualResidentialAddress ||
+            pageType === AddressLookUpPageType.postcodeGeneralPartnerCorrespondenceAddress ||
+            pageType === AddressLookUpPageType.postcodeGeneralPartnerPrincipalOfficeAddress;
+
+          let generalPartner;
+          if (isGeneralPartnerAddress) {
+            generalPartner = await this.generalPartnerService.getGeneralPartner(
+              tokens,
+              ids.transactionId,
+              ids.generalPartnerId
+            );
+          }
+
           response.render(
             super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, { limitedPartnership, ...request.body }, errors)
+            super.makeProps(pageRouting, { limitedPartnership, generalPartner, ...request.body }, errors)
           );
           return;
         }

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -31,6 +31,18 @@ class AddressLookUpController extends AbstractController {
     AddressLookUpPageType.chooseGeneralPartnerCorrespondenceAddress
   ]);
 
+  private static readonly GENERAL_PARTNER_ADDRESS_PAGES: Set<PageType | PageDefault> = new Set([
+    AddressLookUpPageType.postcodeGeneralPartnerUsualResidentialAddress,
+    AddressLookUpPageType.postcodeGeneralPartnerCorrespondenceAddress,
+    AddressLookUpPageType.postcodeGeneralPartnerPrincipalOfficeAddress,
+    AddressLookUpPageType.enterGeneralPartnerUsualResidentialAddress,
+    AddressLookUpPageType.enterGeneralPartnerCorrespondenceAddress,
+    AddressLookUpPageType.enterGeneralPartnerPrincipalOfficeAddress,
+    AddressLookUpPageType.confirmGeneralPartnerUsualResidentialAddress,
+    AddressLookUpPageType.confirmGeneralPartnerPrincipalOfficeAddress,
+    AddressLookUpPageType.confirmGeneralPartnerCorrespondenceAddress
+  ]);
+
   constructor(
     private addressService: AddressService,
     private limitedPartnershipService: LimitedPartnershipService,
@@ -126,13 +138,8 @@ class AddressLookUpController extends AbstractController {
         );
 
         if (errors?.errors) {
-          const isGeneralPartnerAddress =
-            pageType === AddressLookUpPageType.postcodeGeneralPartnerUsualResidentialAddress ||
-            pageType === AddressLookUpPageType.postcodeGeneralPartnerCorrespondenceAddress ||
-            pageType === AddressLookUpPageType.postcodeGeneralPartnerPrincipalOfficeAddress;
-
           let generalPartner;
-          if (isGeneralPartnerAddress) {
+          if ((AddressLookUpController.GENERAL_PARTNER_ADDRESS_PAGES.has(pageType))) {
             generalPartner = await this.generalPartnerService.getGeneralPartner(
               tokens,
               ids.transactionId,
@@ -228,12 +235,7 @@ class AddressLookUpController extends AbstractController {
 
         const pageRouting = super.getRouting(addressLookUpRouting, pageType, request);
 
-        const isGeneralPartnerAddress =
-          pageType === AddressLookUpPageType.enterGeneralPartnerUsualResidentialAddress ||
-          pageType === AddressLookUpPageType.enterGeneralPartnerCorrespondenceAddress ||
-          pageType === AddressLookUpPageType.enterGeneralPartnerPrincipalOfficeAddress;
-
-        const errors = isGeneralPartnerAddress
+        const errors = (AddressLookUpController.GENERAL_PARTNER_ADDRESS_PAGES.has(pageType))
           ? null
           : this.addressService.isValidJurisdictionAndCountry(limitedPartnership?.data?.jurisdiction ?? "", country);
 
@@ -274,15 +276,12 @@ class AddressLookUpController extends AbstractController {
 
         const data = this.getAddressData(pageType, address);
 
-        const isGeneralPartner =
-          pageType === AddressLookUpPageType.confirmGeneralPartnerUsualResidentialAddress ||
-          pageType === AddressLookUpPageType.confirmGeneralPartnerPrincipalOfficeAddress ||
-          pageType === AddressLookUpPageType.confirmGeneralPartnerCorrespondenceAddress;
+        const isGeneralPartnerAddress = (AddressLookUpController.GENERAL_PARTNER_ADDRESS_PAGES.has(pageType));
 
         // store in api
         let result;
 
-        if (isGeneralPartner) {
+        if (isGeneralPartnerAddress) {
           result = await this.generalPartnerService.sendPageData(tokens, ids.transactionId, ids.generalPartnerId, data);
         } else {
           result = await this.limitedPartnershipService.sendPageData(
@@ -298,7 +297,7 @@ class AddressLookUpController extends AbstractController {
           let generalPartner;
           let limitedPartnership;
 
-          if (isGeneralPartner) {
+          if (isGeneralPartnerAddress) {
             generalPartner = await this.generalPartnerService.getGeneralPartner(
               tokens,
               ids.transactionId,

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -115,6 +115,14 @@ describe("Postcode general partner's correspondence address page", () => {
     });
 
     it("should return an error if the postcode is not valid", async () => {
+      const generalPartner = new GeneralPartnerBuilder()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .withForename("Dai")
+        .withSurname("Jones")
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.postcodeGeneralPartnerCorrespondenceAddress,
         premises: null,
@@ -123,6 +131,7 @@ describe("Postcode general partner's correspondence address page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(`The postcode AA1 1AA cannot be found`);
+      expect(res.text).toContain(`${generalPartner.data?.forename?.toUpperCase()} ${generalPartner.data?.surname?.toUpperCase()}`);
 
       expect(appDevDependencies.cacheRepository.cache).toEqual(null);
     });

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
@@ -111,6 +111,13 @@ describe("Postcode general partner's principal office address page", () => {
     });
 
     it("should return an error if the postcode is not valid", async () => {
+      const generalPartner = new GeneralPartnerBuilder()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .isLegalEntity()
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.postcodeGeneralPartnerUsualResidentialAddress,
         premises: null,
@@ -119,6 +126,7 @@ describe("Postcode general partner's principal office address page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(`The postcode AA1 1AA cannot be found`);
+      expect(res.text).toContain(generalPartner.data?.legal_entity_name?.toUpperCase());
 
       expect(appDevDependencies.cacheRepository.cache).toEqual(null);
     });

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
@@ -186,6 +186,14 @@ describe("Postcode Usual Residential Address Page", () => {
     });
 
     it("should return an error if the postcode is not valid", async () => {
+      const generalPartner = new GeneralPartnerBuilder()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .withForename("Dai")
+        .withSurname("Jones")
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.postcodeGeneralPartnerUsualResidentialAddress,
         premises: null,
@@ -194,6 +202,7 @@ describe("Postcode Usual Residential Address Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(`The postcode AA1 1AA cannot be found`);
+      expect(res.text).toContain(`${generalPartner.data?.forename?.toUpperCase()} ${generalPartner.data?.surname?.toUpperCase()}`);
 
       expect(appDevDependencies.cacheRepository.cache).toEqual(null);
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-693
https://companieshouse.atlassian.net/browse/LP-739

### Change description

* Ensure General Partner forename and surname still show when an address postcode error fires on URA
* Fix applies to correspondence (service) and principal address also
* Unit tests added to validate behaviour

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.