### PR TITLE
LP-721 Fix a11y issue on postcode pages for missing label

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -214,8 +214,8 @@
                 "publicRegisterLine1": "WELSH - We'll show the general partner's correspondence address on the public register."
             },
  
-            "nameOrNumberHint": "WELSH - Property name or number (optional)",
-            "postcodeHint": "WELSH - Postcode",
+            "nameOrNumber": "WELSH - Property name or number (optional)",
+            "postcode": "WELSH - Postcode",
             "enterAddressManually": "WELSH - Enter address manually",
             "findAddress": "WELSH - Find address",
             

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -213,8 +213,8 @@
                 "publicRegisterLine1": "We'll show the general partner's correspondence address on the public register."
             },
  
-            "nameOrNumberHint": "Property name or number (optional)",
-            "postcodeHint": "Postcode",
+            "nameOrNumber": "Property name or number (optional)",
+            "postcode": "Postcode",
             "enterAddressManually": "Enter address manually",
             "findAddress": "Find address",
 

--- a/src/views/pages/address/postcode-form.njk
+++ b/src/views/pages/address/postcode-form.njk
@@ -15,8 +15,8 @@
 
     <div class="govuk-!-margin-top-8">
         {{ govukInput({
-            hint: {
-                text: i18n.address.findPostcode.nameOrNumberHint
+            label: {
+                text: i18n.address.findPostcode.nameOrNumber
             },
             id: "premises",
             name: "premises",
@@ -24,8 +24,8 @@
         }) }}
 
         {{ govukInput({
-            hint: {
-                text: i18n.address.findPostcode.postcodeHint
+            label: {
+                text: i18n.address.findPostcode.postcode
             },
             id: "postal_code",
             name: "postal_code",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-721


### Change description
There was an accessibility error on the postcode pages due to the entry field having no label.
Other forms use the label to add description text to the field but postcode was using a hint (taken from prototype)
To fix I have changed from using a hint to a label.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.