### PR TITLE
lp-722: Switch jurisdiction values to match api-enumeration keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.257",
+        "@companieshouse/api-sdk-node": "^2.0.258",
         "@companieshouse/ch-node-utils": "^1.3.13",
         "@companieshouse/node-session-handler": "^5.0.1",
         "@companieshouse/structured-logging-node": "^2.0.1",
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.257",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.257.tgz",
-      "integrity": "sha512-hKPuRtjGrr5mMebkek7JJnFl/bgcW89z9HJsAmREY3QfXGxtizsom23KibLn6K9HxgFKgUiL07luiT08/vDdIQ==",
+      "version": "2.0.258",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.258.tgz",
+      "integrity": "sha512-8z4jmLDDMcQsnJFQjJqNF6XvhfDlI2i3wzfUq/G0Qm71fGEmg+iDqL25rNvfujTF8iN1nCgIBTr/GF7zj72qzQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://github.com/companieshouse/limited-partnerships-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.257",
+    "@companieshouse/api-sdk-node": "^2.0.258",
     "@companieshouse/ch-node-utils": "^1.3.13",
     "@companieshouse/node-session-handler": "^5.0.1",
     "@companieshouse/structured-logging-node": "^2.0.1",

--- a/src/views/includes/jurisdiction-form.njk
+++ b/src/views/includes/jurisdiction-form.njk
@@ -25,7 +25,7 @@
       {
         id: "jurisdiction-england-wales",
         name: "jurisdiction",
-        value: "England and Wales",
+        value: "england-wales",
         text: i18n.whereIsTheJurisdiction.options.EnglandWales,
         attributes: {
           "required": true
@@ -34,7 +34,7 @@
       {
         id: "jurisdiction-northern-ireland",
         name: "jurisdiction",
-        value: "Northern Ireland",
+        value: "northern-ireland",
         text: i18n.whereIsTheJurisdiction.options.NorthernIreland,
         attributes: {
           "required": true

--- a/src/views/includes/jurisdiction-scotland.njk
+++ b/src/views/includes/jurisdiction-scotland.njk
@@ -7,7 +7,7 @@
       
 <form class="form" action={{ props.currentUrl }} method="post">
   <input type="hidden" name="pageType" value={{ props.pageType }}>  
-  <input type="hidden" name="jurisdiction" value="Scotland">
+  <input type="hidden" name="jurisdiction" value="scotland">
   {% include "includes/csrf_token.njk" %}
   {% include "includes/errors.njk" %}
   {{ govukButton({


### PR DESCRIPTION
### JIRA link

[LP-722](https://companieshouse.atlassian.net/browse/LP-722)

### Change description

Switch Jurisdiction use API enumeration keys. These keys are then used within a change to chips filing consumer that will map these keys to their specific chips counterpart during processing.

Relates to the following API changes - https://github.com/companieshouse/limited-partnerships-api/pull/131

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.

[LP-722]: https://companieshouse.atlassian.net/browse/LP-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ