### PR TITLE
Sonar fix for RequestHandler promise return type

### DIFF
--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -225,8 +225,8 @@ class AddressLookUpController extends AbstractController {
     };
   }
 
-  sendManualAddress(): RequestHandler {
-    return async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+  sendManualAddress() {
+    return async (request: Request, response: Response, next: NextFunction) => {
       try {
         this.addressService.setI18n(response.locals.i18n);
 

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import escape from "escape-html";
 import { Address } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
@@ -64,7 +64,7 @@ class AddressLookUpController extends AbstractController {
     super();
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         this.addressService.setI18n(response.locals.i18n);
@@ -126,7 +126,7 @@ class AddressLookUpController extends AbstractController {
     return addressList;
   }
 
-  postcodeValidation(): RequestHandler {
+  postcodeValidation() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         this.addressService.setI18n(response.locals.i18n);
@@ -211,7 +211,7 @@ class AddressLookUpController extends AbstractController {
     response.cookie(APPLICATION_CACHE_KEY, cache, cookieOptions);
   }
 
-  selectAddress(): RequestHandler {
+  selectAddress() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         this.addressService.setI18n(response.locals.i18n);
@@ -276,7 +276,7 @@ class AddressLookUpController extends AbstractController {
     };
   }
 
-  confirmAddress(): RequestHandler {
+  confirmAddress() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         this.addressService.setI18n(response.locals.i18n);
@@ -420,7 +420,7 @@ class AddressLookUpController extends AbstractController {
     response.redirect(pageRouting.nextUrl);
   }
 
-  generalPartnerUsualResidentialaddressChoice(): RequestHandler {
+  generalPartnerUsualResidentialaddressChoice() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const pageType = super.extractPageTypeOrThrowError(request, AddressLookUpPageType);
@@ -433,7 +433,7 @@ class AddressLookUpController extends AbstractController {
     };
   }
 
-  generalPartnerTerritoryChoice(): RequestHandler {
+  generalPartnerTerritoryChoice() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const { ids, pageType } = super.extract(request);

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -226,7 +226,7 @@ class AddressLookUpController extends AbstractController {
   }
 
   sendManualAddress(): RequestHandler {
-    return async (request: Request, response: Response, next: NextFunction) => {
+    return async (request: Request, response: Response, next: NextFunction): Promise<void> => {
       try {
         this.addressService.setI18n(response.locals.i18n);
 

--- a/src/presentation/controller/global/Controller.ts
+++ b/src/presentation/controller/global/Controller.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 
 import globalsRouting from "./Routing";
 import AbstractController from "../AbstractController";
@@ -15,7 +15,7 @@ class GlobalController extends AbstractController {
     super();
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         // example error message using the locales json files
@@ -34,7 +34,7 @@ class GlobalController extends AbstractController {
     };
   }
 
-  getSignOut(): RequestHandler {
+  getSignOut() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const previousPageUrl = this.getPreviousPageUrl(request);
@@ -50,7 +50,7 @@ class GlobalController extends AbstractController {
     };
   }
 
-  signOutChoice(): RequestHandler {
+  signOutChoice() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         if (request.body["sign_out"] === "yes") {
@@ -66,7 +66,7 @@ class GlobalController extends AbstractController {
     };
   }
 
-  getHealthcheck(): RequestHandler {
+  getHealthcheck() {
     return (_request: Request, response: Response, next: NextFunction) => {
       try {
         response.status(200).json({ status: "OK" });

--- a/src/presentation/controller/registration/GeneralPartnerController.ts
+++ b/src/presentation/controller/registration/GeneralPartnerController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
 import GeneralPartnerService from "../../../application/service/GeneralPartnerService";
@@ -18,7 +18,7 @@ class GeneralPartnerController extends AbstractController {
     this.generalPartnerService = generalPartnerService;
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, pageType, ids } = super.extract(request);
@@ -53,7 +53,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  generalPartnerChoice(): RequestHandler {
+  generalPartnerChoice() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const { ids } = super.extract(request);
@@ -70,7 +70,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  getReviewPage(): RequestHandler {
+  getReviewPage() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, pageType, ids } = super.extract(request);
@@ -99,7 +99,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  createGeneralPartner(): RequestHandler {
+  createGeneralPartner() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);
@@ -131,7 +131,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  sendPageData(): RequestHandler {
+  sendPageData() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);
@@ -160,7 +160,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  postReviewPage(): RequestHandler {
+  postReviewPage() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { ids, tokens } = super.extract(request);
@@ -204,7 +204,7 @@ class GeneralPartnerController extends AbstractController {
     };
   }
 
-  postRemovePage(): RequestHandler {
+  postRemovePage() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { ids, tokens } = super.extract(request);

--- a/src/presentation/controller/registration/LimitedPartnerController.ts
+++ b/src/presentation/controller/registration/LimitedPartnerController.ts
@@ -104,7 +104,7 @@ class LimitedPartnerController extends AbstractController {
     };
   }
 
-  sendPageData(): RequestHandler {
+  sendPageData() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);

--- a/src/presentation/controller/registration/LimitedPartnerController.ts
+++ b/src/presentation/controller/registration/LimitedPartnerController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
 import LimitedPartnerService from "../../../application/service/LimitedPartnerService";
@@ -20,7 +20,7 @@ class LimitedPartnerController extends AbstractController {
     this.limitedPartnerService = limitedPartnerService;
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, pageType, ids } = super.extract(request);
@@ -55,7 +55,7 @@ class LimitedPartnerController extends AbstractController {
     };
   }
 
-  limitedPartnerChoice(): RequestHandler {
+  limitedPartnerChoice() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const { ids } = super.extract(request);
@@ -72,7 +72,7 @@ class LimitedPartnerController extends AbstractController {
     };
   }
 
-  createLimitedPartner(): RequestHandler {
+  createLimitedPartner() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import escape from "escape-html";
 import { LimitedPartnership, PartnershipType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
@@ -26,7 +26,7 @@ class LimitedPartnershipController extends AbstractController {
     this.cacheService = cacheService;
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, pageType, ids } = super.extract(request);
@@ -71,7 +71,7 @@ class LimitedPartnershipController extends AbstractController {
     }
   }
 
-  createTransactionAndFirstSubmission(): RequestHandler {
+  createTransactionAndFirstSubmission() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens } = super.extract(request);
@@ -112,7 +112,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  closeTransaction(): RequestHandler {
+  closeTransaction() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);
@@ -133,7 +133,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  redirectWhichTypeWithIds(): RequestHandler {
+  redirectWhichTypeWithIds() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);
@@ -158,7 +158,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  redirectAndCacheSelection(): RequestHandler {
+  redirectAndCacheSelection() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const type = super.extractPageTypeOrThrowError(request, RegistrationPageType);
@@ -179,7 +179,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  sendPageData(): RequestHandler {
+  sendPageData() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);
@@ -209,7 +209,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  getPageRoutingTermSic(): RequestHandler {
+  getPageRoutingTermSic() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, pageType, ids } = super.extract(request);
@@ -249,7 +249,7 @@ class LimitedPartnershipController extends AbstractController {
     };
   }
 
-  sendSicCodesPageData(): RequestHandler {
+  sendSicCodesPageData() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens, ids } = super.extract(request);

--- a/src/presentation/controller/transition/TransitionController.ts
+++ b/src/presentation/controller/transition/TransitionController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import AbstractController from "../AbstractController";
 import transitionRouting from "./Routing";
 import TransitionPageType from "./PageType";
@@ -16,7 +16,7 @@ class TransitionController extends AbstractController {
     super();
   }
 
-  getPageRouting(): RequestHandler {
+  getPageRouting() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const { pageType } = super.extract(request);
@@ -31,7 +31,7 @@ class TransitionController extends AbstractController {
     };
   }
 
-  getConfirmPage(): RequestHandler {
+  getConfirmPage() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens } = super.extract(request);
@@ -62,7 +62,7 @@ class TransitionController extends AbstractController {
     };
   }
 
-  limitedPartnershipConfirm(): RequestHandler {
+  limitedPartnershipConfirm() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
         const { pageType } = super.extract(request);
@@ -77,7 +77,7 @@ class TransitionController extends AbstractController {
     };
   }
 
-  checkCompanyNumber(): RequestHandler {
+  checkCompanyNumber() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
         const { tokens } = super.extract(request);


### PR DESCRIPTION
### JIRA link
N/A


### Change description
Fix sonar issue on RequestHandler return type
removed RequestHandler from function signature to let TypeScript infer the correct return type.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.