### PR TITLE
Exclude the healthcheck from running the localisation middleware

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -60,7 +60,7 @@ export const appConfig = (app: express.Application) => {
   // middlewares
   app.use(serviceAvailabilityMiddleware);
   app.use(config.excludedPaths, journeyDetectionMiddleware);
-  app.use(localisationMiddleware);
+  app.use(config.excludedPaths, localisationMiddleware);
 
   const cookieConfig = {
     cookieName: "__SID",

--- a/src/presentation/test/integration/error-404.test.ts
+++ b/src/presentation/test/integration/error-404.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 
 import app from "./app";
-import { HEALTHCHECK_URL } from "../../controller/global/Routing";
+import { WHICH_TYPE_URL } from "presentation/controller/registration/url";
 
 describe("Error pages", () => {
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe("Error pages", () => {
   });
 
   it("should render the 'page-not-found' page", async () => {
-    const response = await request(app).get(HEALTHCHECK_URL + "wrong-url");
+    const response = await request(app).get(WHICH_TYPE_URL + "wrong-url");
 
     expect(response.status).toEqual(404);
     expect(response.text).toContain("Page not found");

--- a/src/presentation/test/integration/error-500.test.ts
+++ b/src/presentation/test/integration/error-500.test.ts
@@ -1,35 +1,15 @@
-import request from "supertest";
-import { NextFunction, Request, Response } from "express";
-import app from "./app";
-import { HEALTHCHECK_URL } from "../../controller/global/Routing";
+import LimitedPartnershipController from "../../controller/registration/LimitedPartnershipController";
 
-jest.mock("../../controller/global/Controller", () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      ...jest.requireActual("../../controller/global/Controller"),
-      getPageRouting: jest.fn().mockImplementation(() => {
-        return (_req: Request, _res: Response, next: NextFunction) => {
-          return next();
-        };
-      }),
-      getSignOut: jest.fn().mockImplementation(() => {
-        return (_req: Request, _res: Response, next: NextFunction) => {
-          return next();
-        };
-      }),
-      signOutChoice: jest.fn().mockImplementation(() => {
-        return (_req: Request, _res: Response, next: NextFunction) => {
-          return next();
-        };
-      }),
-      getHealthcheck: jest.fn().mockImplementation(() => {
-        return (_req: Request, _res: Response, next: NextFunction) => {
-          next(new Error("Error 500"));
-        };
-      }),
-    };
-  });
+// we have to create the spy before the real one is initialised when we import app
+jest.spyOn(LimitedPartnershipController.prototype, "getPageRouting").mockImplementation(() => {
+  return (req, res, next) => {
+    return Promise.resolve().then(() => next(new Error("Mocked Error 500")));
+  };
 });
+
+import request from "supertest";
+import app from "./app";
+import { WHICH_TYPE_URL } from "presentation/controller/registration/url";
 
 describe("Error 500", () => {
   beforeEach(() => {
@@ -37,7 +17,7 @@ describe("Error 500", () => {
   });
 
   it("should render the 'error-page' page", async () => {
-    const response = await request(app).get(HEALTHCHECK_URL);
+    const response = await request(app).get(WHICH_TYPE_URL);
 
     expect(response.status).toEqual(500);
     expect(response.text).toContain("Sorry, the service is unavailable");


### PR DESCRIPTION
### JIRA link
N/A


### Change description
Make sure the localisation middleware does not run when the healthcheck endpoint is called (every 3-5 seconds in Live)
The tests changed were using healthcheck url and checking for the translated text to be returned. Now we have excluded healthcheck from the localisation, no text is returned so tests have been changed to use WHICH_TYPE, which will use localisation and get the text returned in the response.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.