### PR TITLE
LP-730 Placement of 'enter address' screen error messages

### DIFF
--- a/src/views/enter-general-partner-correspondence-address.njk
+++ b/src/views/enter-general-partner-correspondence-address.njk
@@ -35,6 +35,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/general-partner-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-general-partner-principal-office-address.njk
+++ b/src/views/enter-general-partner-principal-office-address.njk
@@ -36,6 +36,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/general-partner-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-general-partner-usual-residential-address.njk
+++ b/src/views/enter-general-partner-usual-residential-address.njk
@@ -34,6 +34,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/general-partner-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-limited-partner-principal-office-address.njk
+++ b/src/views/enter-limited-partner-principal-office-address.njk
@@ -35,6 +35,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/limited-partner-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-limited-partner-usual-residential-address.njk
+++ b/src/views/enter-limited-partner-usual-residential-address.njk
@@ -34,6 +34,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/limited-partner-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-principal-place-of-business-address.njk
+++ b/src/views/enter-principal-place-of-business-address.njk
@@ -20,6 +20,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/proposed-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/enter-registered-office-address.njk
+++ b/src/views/enter-registered-office-address.njk
@@ -20,6 +20,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
       {% include "includes/proposed-name.njk" %}
 
       <fieldset class="govuk-fieldset">

--- a/src/views/pages/address/enter-address-fields.njk
+++ b/src/views/pages/address/enter-address-fields.njk
@@ -4,8 +4,6 @@
 {% set validateAddressLine1 = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.addressLine1Missing | escape + "', '" + i18n.address.enterAddress.errorMessages.addressLine1Length | escape + "');" %}
 {% set validateTownOrCity = "validateInput(this, 50, '" + i18n.address.enterAddress.errorMessages.townOrCityMissing | escape + "', '" + i18n.address.enterAddress.errorMessages.townOrCityLength | escape + "');" %}
 
-{% include "includes/errors.njk" %}
-        
 {% include "includes/validators.njk" %}
 
 <div>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-730

### Change description

* Red box error messages are now displayed in the correct location on the screen
* Fixed for registered office address and principal place of business address entry
* Was also necessary to make the same change in the other 'enter address' templates

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.