### PR TITLE
Lp 813 Ensure country is displayed in addresses values

### DIFF
--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -50,22 +50,10 @@ describe("Check Your Answers Page", () => {
       expect(res.text).toContain(limitedPartnership?.data?.partnership_name?.toUpperCase());
       expect(res.text).toContain(limitedPartnership?.data?.name_ending?.toUpperCase());
       expect(res.text).toContain(limitedPartnership?.data?.email);
-
-      expect(res.text).toContain("4 Line 1");
-      expect(res.text).toContain("Line 2");
-      expect(res.text).toContain("Stoke-On-Trent");
-      expect(res.text).toContain("England");
-      expect(res.text).toContain("ST6 3LJ");
-
-      expect(res.text).toContain("2 Line 3");
-      expect(res.text).toContain("Line 4");
-      expect(res.text).toContain("Burton-On-Trent");
-      expect(res.text).toContain("England");
-      expect(res.text).toContain("DE6 3LJ");
-
+      expect(res.text).toContain("4 Line 1, Line 2, Stoke-On-Trent, England, ST6 3LJ");
+      expect(res.text).toContain("2 Line 3, Line 4, Burton-On-Trent, England, DE6 3LJ");
       expect(res.text).toContain("Such term as decided by the partners within the partnership agreement");
       expect(res.text).toContain("12345,67890");
-
       expect(res.text).toContain("name#partnership_name");
       expect(res.text).toContain("email#email");
       expect(res.text).toContain("where-is-the-jurisdiction#jurisdiction");

--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -104,7 +104,7 @@
               text: i18n.checkYourAnswersPage.headingRegisteredOfficeAddress
             },
             value: {
-              text: macros.formatAddress(props.data.limitedPartnership.data.registered_office_address)
+              text: macros.formatAddress(props.data.limitedPartnership.data.registered_office_address, true)
             }
           },
           {
@@ -112,7 +112,7 @@
               text: i18n.checkYourAnswersPage.headingPrincipalPlaceOfBusinessAddress
             },
             value: {
-              text: macros.formatAddress(props.data.limitedPartnership.data.principal_place_of_business_address)
+              text: macros.formatAddress(props.data.limitedPartnership.data.principal_place_of_business_address, true)
             }
           },         
           {

--- a/src/views/includes/macros.njk
+++ b/src/views/includes/macros.njk
@@ -1,4 +1,4 @@
-{% macro formatAddress(address) %}
+{% macro formatAddress(address, isIncludingCountry) %}
   {% set premises = '' %}
   {% set address_line_1 = '' %}
   {% set address_line_2 = '' %}
@@ -20,11 +20,12 @@
     {% set locality = capitalizeEachWord(address.locality) + ', ' %} 
   {% endif %}
 
-  {% if address.country %} 
-    {% set country = capitalizeEachWord(address.country) + ', ' %} 
-  {% endif %}
-
-  {% set address = premises + address_line_1 + address_line_2 + locality + country + address.postal_code %}
+  {% if address.country and isIncludingCountry %} 
+    {% set country = capitalizeEachWord(address.country) + ', ' %}
+    {% set address = premises + address_line_1 + address_line_2 + locality + country + address.postal_code %} 
+  {% else %}
+    {% set address = premises + address_line_1 + address_line_2 + locality + address.postal_code %}
+  {% endif %}  
 
   {{ address }}
 {% endmacro %}

--- a/src/views/includes/macros.njk
+++ b/src/views/includes/macros.njk
@@ -20,7 +20,11 @@
     {% set locality = capitalizeEachWord(address.locality) + ', ' %} 
   {% endif %}
 
-  {% set address = premises + address_line_1 + address_line_2 + locality + address.postal_code %}
+  {% if address.country %} 
+    {% set country = capitalizeEachWord(address.country) + ', ' %} 
+  {% endif %}
+
+  {% set address = premises + address_line_1 + address_line_2 + locality + country + address.postal_code %}
 
   {{ address }}
 {% endmacro %}

--- a/src/views/pages/address/choose-address-form.njk
+++ b/src/views/pages/address/choose-address-form.njk
@@ -4,7 +4,7 @@
 {% for address in props.data.addressList %}
   {% set newItem = {
     value: address | dump,
-    text: macros.formatAddress(address),
+    text: macros.formatAddress(address, false),
     attributes: {
       required: true,
       "radio-event-id": "address-radio-selected"


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-813

### Change description

Updated macros to include country added flag to make this optional as it will not be required in all instances; only on the check your answers page.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.