### PR TITLE
LP-754 Ensure partner name displayed when validation error is raised

### DIFF
--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -306,10 +306,26 @@ class AddressLookUpController extends AbstractController {
         }
 
         if (errors?.errors) {
+          let generalPartner;
+          let limitedPartner;
+          if (AddressLookUpController.GENERAL_PARTNER_ADDRESS_PAGES.has(pageType)) {
+            generalPartner = await this.generalPartnerService.getGeneralPartner(
+              tokens,
+              ids.transactionId,
+              ids.generalPartnerId
+            );
+          } else if (AddressLookUpController.LIMITED_PARTNER_ADDRESS_PAGES.has(pageType)) {
+            limitedPartner = await this.limitedPartnerService.getLimitedPartner(
+              tokens,
+              ids.transactionId,
+              ids.limitedPartnerId
+            );
+          }
+
           const cacheById = this.cacheService.getDataFromCacheById(request.signedCookies, ids.transactionId);
           response.render(
             super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, { address, limitedPartnership, cache: { ...cacheById } }, errors)
+            super.makeProps(pageRouting, { address, limitedPartnership, generalPartner, limitedPartner, cache: { ...cacheById } }, errors)
           );
 
           return;

--- a/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-correspondence-address.test.ts
@@ -255,6 +255,8 @@ describe("Enter Correspondence Address Page", () => {
         .isPerson()
         .build();
 
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterGeneralPartnerCorrespondenceAddress,
         ...generalPartner.data?.service_address,
@@ -264,6 +266,7 @@ describe("Enter Correspondence Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.postcodeFormat);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(`${generalPartner.data?.forename?.toUpperCase()} ${generalPartner.data?.surname?.toUpperCase()}`);
     });
 
     it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {

--- a/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-principal-office-address.test.ts
@@ -127,6 +127,8 @@ describe("Enter general partner's principal office manual address page", () => {
         .isPerson()
         .build();
 
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterGeneralPartnerPrincipalOfficeAddress,
         ...generalPartner.data?.principal_office_address,
@@ -136,6 +138,7 @@ describe("Enter general partner's principal office manual address page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.postcodeFormat);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(`${generalPartner.data?.forename?.toUpperCase()} ${generalPartner.data?.surname?.toUpperCase()}`);
     });
 
     it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {

--- a/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-usual-residential-address.test.ts
@@ -255,6 +255,8 @@ describe("Enter Usual Residential Address Page", () => {
         .isPerson()
         .build();
 
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterGeneralPartnerUsualResidentialAddress,
         ...generalPartner.data?.usual_residential_address,
@@ -264,6 +266,7 @@ describe("Enter Usual Residential Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.postcodeFormat);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(`${generalPartner.data?.forename?.toUpperCase()} ${generalPartner.data?.surname?.toUpperCase()}`);
     });
 
     it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {

--- a/src/presentation/test/integration/registration/limitedPartner/address/enter-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/enter-limited-partner-principal-office-address.test.ts
@@ -253,6 +253,8 @@ describe("Enter Limited Partner Principal Office Address Page", () => {
         .isLegalEntity()
         .build();
 
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterLimitedPartnerPrincipalOfficeAddress,
         ...limitedPartner.data?.principal_office_address,
@@ -262,6 +264,7 @@ describe("Enter Limited Partner Principal Office Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.postcodeFormat);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartner.data?.legal_entity_name?.toUpperCase());
     });
 
     it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {

--- a/src/presentation/test/integration/registration/limitedPartner/address/enter-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/enter-limited-partner-usual-residential-address.test.ts
@@ -253,6 +253,8 @@ describe("Enter Limited Partner Usual Residential Address Page", () => {
         .isLegalEntity()
         .build();
 
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartner]);
+
       const res = await request(app).post(URL).send({
         pageType: AddressPageType.enterLimitedPartnerUsualResidentialAddress,
         ...limitedPartner.data?.usual_residential_address,
@@ -262,6 +264,7 @@ describe("Enter Limited Partner Usual Residential Address Page", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain(enTranslationText.address.enterAddress.errorMessages.postcodeFormat);
       expect(res.text).toContain(enTranslationText.govUk.error.title);
+      expect(res.text).toContain(limitedPartner.data?.legal_entity_name?.toUpperCase());
     });
 
     it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-754

### Change description

* General Partner and Limited Partner names now display on the 'enter manual address' screens if a typescript validation error is raised
* Tests added for all pages where this was occurring

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.