### PR TITLE
LP-798 Redirect from remove when limited partner list is empty

### DIFF
--- a/src/presentation/controller/registration/LimitedPartnerController.ts
+++ b/src/presentation/controller/registration/LimitedPartnerController.ts
@@ -5,7 +5,7 @@ import LimitedPartnerService from "../../../application/service/LimitedPartnerSe
 import registrationsRouting from "./Routing";
 import AbstractController from "../AbstractController";
 import RegistrationPageType from "./PageType";
-import { ADD_LIMITED_PARTNER_PERSON_URL, ADD_LIMITED_PARTNER_LEGAL_ENTITY_URL, CHECK_YOUR_ANSWERS_URL } from "./url";
+import { ADD_LIMITED_PARTNER_PERSON_URL, ADD_LIMITED_PARTNER_LEGAL_ENTITY_URL, CHECK_YOUR_ANSWERS_URL, LIMITED_PARTNERS_URL } from "./url";
 import { LimitedPartner } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 import { PageRouting } from "../PageRouting";
 
@@ -111,6 +111,12 @@ class LimitedPartnerController extends AbstractController {
           );
 
           limitedPartners = await this.limitedPartnerService.getLimitedPartners(tokens, ids.transactionId);
+        }
+
+        if (limitedPartners.length === 0) {
+          const redirect = super.insertIdsInUrl(LIMITED_PARTNERS_URL, ids.transactionId, ids.submissionId);
+          response.redirect(redirect);
+          return;
         }
 
         response.render(

--- a/src/presentation/test/integration/registration/limitedPartner/review-limited-partners.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/review-limited-partners.test.ts
@@ -9,6 +9,7 @@ import {
   ADD_LIMITED_PARTNER_LEGAL_ENTITY_URL,
   ADD_LIMITED_PARTNER_PERSON_URL,
   CHECK_YOUR_ANSWERS_URL,
+  LIMITED_PARTNERS_URL,
   REVIEW_LIMITED_PARTNERS_URL
 } from "../../../../controller/registration/url";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
@@ -63,17 +64,14 @@ describe("Review Limited Partners Page", () => {
     });
 
     describe("Empty list", () => {
-      it("should load the review limited partners page and contains empty list text", async () => {
+      it("should redirect to limited partners start page when list is empty", async () => {
         appDevDependencies.limitedPartnerGateway.feedLimitedPartners([]);
 
         const res = await request(app).get(URL);
 
-        expect(res.status).toBe(200);
-
-        expect(res.text).toContain(
-          `${enTranslationText.reviewLimitedPartnersPage.title} - ${enTranslationText.service} - GOV.UK`
-        );
-        expect(res.text).toContain(enTranslationText.reviewLimitedPartnersPage.limitedPartnersAdded.emptyList);
+        const redirectUrl = getUrl(LIMITED_PARTNERS_URL);
+        expect(res.status).toBe(302);
+        expect(res.text).toContain(`Redirecting to ${redirectUrl}`);
       });
     });
   });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-798

### Change description

Review page get function - added interceptor to redirect to the start of the limited partner journey when the list of limited partners is empty.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.