### PR TITLE
LP-903 Fix 'Back' link on the Review General Partners page

### DIFF
--- a/src/presentation/controller/registration/routing/generalPartner.ts
+++ b/src/presentation/controller/registration/routing/generalPartner.ts
@@ -47,7 +47,7 @@ const registrationRoutingAddGeneralPartnerLegalEntity = {
 // principal office address
 
 const registrationRoutingReviewGeneralPartners = {
-  previousUrl: url.GENERAL_PARTNER_CHOICE_URL,
+  previousUrl: CONFIRM_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_URL,
   currentUrl: url.REVIEW_GENERAL_PARTNERS_URL,
   nextUrl: url.LIMITED_PARTNERS_URL,
   pageType: RegistrationPageType.reviewGeneralPartners

--- a/src/views/general-partners.njk
+++ b/src/views/general-partners.njk
@@ -1,21 +1,12 @@
 {% extends "layout.njk" %}
 
+{% set originalPage = "general-partners" %}
+{% set newPage = "standard-industrial-classification-code" %}
+
 {% block backLink %}
-  {% set partnershipType = props.data.limitedPartnership.data.partnership_type %}
 
-  {% if (partnershipType == "LP") or (partnershipType == "SLP") %}
-    {% set hrefValue = props.currentUrl | replace("general-partners", "standard-industrial-classification-code") %}
-  {% else %}
-     {% set hrefValue = props.previousUrl %}
-  {% endif %}
+  {% include "includes/configurable-back-link.njk" %}
 
-  {{ govukBackLink({
-    text: i18n.links.back,
-    attributes: {
-      "data-event-id": "back-link"
-    },
-    href: hrefValue
-  }) }}
 {% endblock %}
 
 {% set pageTitle = i18n.generalPartnersPage.title  %}

--- a/src/views/general-partners.njk
+++ b/src/views/general-partners.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
-{% set originalPage = "general-partners" %}
-{% set newPage = "standard-industrial-classification-code" %}
+{% set currentPage = "general-partners" %}
+{% set backPage = "standard-industrial-classification-code" %}
 
 {% block backLink %}
 

--- a/src/views/includes/configurable-back-link.njk
+++ b/src/views/includes/configurable-back-link.njk
@@ -1,0 +1,15 @@
+{% set partnershipType = props.data.limitedPartnership.data.partnership_type %}
+
+{% if (partnershipType == "LP") or (partnershipType == "SLP") %}
+  {% set hrefValue = props.currentUrl | replace(originalPage, newPage) %}
+{% else %}
+    {% set hrefValue = props.previousUrl %}
+{% endif %}
+
+{{ govukBackLink({
+  text: i18n.links.back,
+  attributes: {
+    "data-event-id": "back-link"
+  },
+  href: hrefValue
+}) }}

--- a/src/views/includes/configurable-back-link.njk
+++ b/src/views/includes/configurable-back-link.njk
@@ -1,7 +1,7 @@
 {% set partnershipType = props.data.limitedPartnership.data.partnership_type %}
 
 {% if (partnershipType == "LP") or (partnershipType == "SLP") %}
-  {% set hrefValue = props.currentUrl | replace(originalPage, newPage) %}
+  {% set hrefValue = props.currentUrl | replace(currentPage, backPage) %}
 {% else %}
     {% set hrefValue = props.previousUrl %}
 {% endif %}

--- a/src/views/review-general-partners.njk
+++ b/src/views/review-general-partners.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
-{% set originalPage = "review-general-partners" %}
-{% set newPage = "standard-industrial-classification-code" %}
+{% set currentPage = "review-general-partners" %}
+{% set backPage = "standard-industrial-classification-code" %}
 
 {% block backLink %}
 

--- a/src/views/review-general-partners.njk
+++ b/src/views/review-general-partners.njk
@@ -1,5 +1,14 @@
 {% extends "layout.njk" %}
 
+{% set originalPage = "review-general-partners" %}
+{% set newPage = "standard-industrial-classification-code" %}
+
+{% block backLink %}
+
+  {% include "includes/configurable-back-link.njk" %}
+
+{% endblock %}
+
 {% set pageTitle = i18n.reviewGeneralPartnersPage.title  %}
 
 {% set list = props.data.generalPartners %}
@@ -11,6 +20,6 @@
 
 {% block content %}
 
-    {% include "pages/review-partners.njk" %}
+  {% include "pages/review-partners.njk" %}
 
 {% endblock %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-903

### Change description

* Link now correctly takes user back to SIC codes page or PPOB page based on LP type
* New configurable include added for 'Back' link and also used on the General Partners choice page
* Test added

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.

[LP-904]: https://companieshouse.atlassian.net/browse/LP-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ