### PR TITLE
LP-915 Highlight postcode error for overseas addresses

### DIFF
--- a/src/views/enter-general-partner-correspondence-address.njk
+++ b/src/views/enter-general-partner-correspondence-address.njk
@@ -59,6 +59,7 @@
               label: {
                 text: i18n.address.enterAddress.generalPartner.correspondenceAddress.postcodeOptional
               },
+              errorMessage: props.errors.postal_code if props.errors,
               classes: "govuk-input--width-10",
               id: "postal_code",
               name: "postal_code",

--- a/src/views/enter-general-partner-principal-office-address.njk
+++ b/src/views/enter-general-partner-principal-office-address.njk
@@ -58,6 +58,7 @@
               label: {
                 text: i18n.address.enterAddress.generalPartner.principalOfficeAddress.postcodeOptional
               },
+              errorMessage: props.errors.postal_code if props.errors,
               classes: "govuk-input--width-10",
               id: "postal_code",
               name: "postal_code",

--- a/src/views/enter-general-partner-usual-residential-address.njk
+++ b/src/views/enter-general-partner-usual-residential-address.njk
@@ -56,6 +56,7 @@
               label: {
                 text: i18n.address.enterAddress.generalPartner.usualResidentialAddress.postcodeOptional
               },
+              errorMessage: props.errors.postal_code if props.errors,
               classes: "govuk-input--width-10",
               id: "postal_code",
               name: "postal_code",

--- a/src/views/enter-limited-partner-principal-office-address.njk
+++ b/src/views/enter-limited-partner-principal-office-address.njk
@@ -59,6 +59,7 @@
               label: {
                 text: i18n.address.enterAddress.limitedPartner.principalOfficeAddress.postcodeOptional
               },
+              errorMessage: props.errors.postal_code if props.errors,
               classes: "govuk-input--width-10",
               id: "postal_code",
               name: "postal_code",

--- a/src/views/enter-limited-partner-usual-residential-address.njk
+++ b/src/views/enter-limited-partner-usual-residential-address.njk
@@ -56,6 +56,7 @@
               label: {
                 text: i18n.address.enterAddress.limitedPartner.usualResidentialAddress.postcodeOptional
               },
+              errorMessage: props.errors.postal_code if props.errors,
               classes: "govuk-input--width-10",
               id: "postal_code",
               name: "postal_code",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-915

### Change description

When the user selects "overseas" for all general and limited partner addresses, then the change ensures that the postcode field is highlighted on the manual entry page for invalid format.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.