### PR TITLE
LP-971 Ensure all capital contribution fields are accessible

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -327,6 +327,8 @@
     
     "capitalContribution" : {
         "title" : "WELSH - What is their total capital contribution?",
+        "currencyTypeLabel": "WELSH - Contribution currency type",
+        "valueLabel": "WELSH - Contribution currency value",
         "hint" : "WELSH - Enter the total value of all monetary and non-monetary contributions",
         "amountHint": "WELSH - Enter the value, for example:",
         "amountMinHint": "WELSH - if they contributed £0.01 enter 0.01", 

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -326,6 +326,8 @@
 
     "capitalContribution" : {
        "title" : "What is their total capital contribution?",
+       "currencyTypeLabel": "Contribution currency type",
+       "valueLabel": "Contribution currency value",
        "hint" : "Enter the total value of all monetary and non-monetary contributions",
        "amountHint": "Enter the value, for example:",
        "amountMinHint": "if they contributed £0.01 enter 0.01", 

--- a/src/views/includes/capital-contribution.njk
+++ b/src/views/includes/capital-contribution.njk
@@ -22,6 +22,11 @@
   {%- endset %}
 
   {{ govukInput({ 
+    label: {
+      text: i18n.capitalContribution.valueLabel,
+      classes: "govuk-label govuk-label--m",
+      isPageHeading: false
+     },
     hint: {
       html: hintHtml
     },  

--- a/src/views/includes/currencies.njk
+++ b/src/views/includes/currencies.njk
@@ -174,11 +174,11 @@
 ] %}
 
 {{ govukSelect({
-  idPrefix: contributionCurrencyTypeId,
+  id: contributionCurrencyTypeId,
   name: contributionCurrencyTypeId,
   value: contributionCurrencyValue,
   label: {
-    text: currencyText,
+    text: i18n.capitalContribution.currencyTypeLabel,
     classes: currencyFont,
     isPageHeading: false
   },


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-971

### Change description

- New label for the contribution value field
- Fix for the contribution subtypes a11y error
- New local entries for the labels

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.