### PR TITLE
LP-969 General partner legal entity disqualification stmt

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -49,9 +49,7 @@
                 "yesHintTitle" : "WELSH - What is the general partner's previous name?",
                 "yesHint" : "WELSH - If the partner has more than one previous name, separate each name with a comma.",
                 "no" : "WELSH - No"
-            },
-            "disqualificationStatement" : "WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.",
-            "disqualificationStatementLegend" : "WELSH - General partner - person - disqualification statement"
+            }            
         },
         "limitedPartner": {
             "title": "WELSH - Add a limited partner (person)",
@@ -478,7 +476,9 @@
 
     "generalPartnersPage": {
         "title": "WELSH - You now need to tell us about the general partners",
-        "pageInformation": "WELSH - If the partnership has more than one general partner, you'll add them one at a time."
+        "pageInformation": "WELSH - If the partnership has more than one general partner, you'll add them one at a time.",
+        "disqualificationStatement" : "WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907..",
+        "disqualificationStatementLegend" : "WELSH - General partner - person - disqualification statement"
     },
 
     "govUk" : {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -49,9 +49,7 @@
                 "yesHintTitle" : "What is the general partner's previous name?",
                 "yesHint" : "If the partner has more than one previous name, separate each name with a comma.",
                 "no" : "No"
-            },
-            "disqualificationStatement" : "I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.",
-            "disqualificationStatementLegend" : "General partner - person - disqualification statement"
+            }            
         },
         "limitedPartner": {
             "title": "Add a limited partner (person)",
@@ -476,7 +474,9 @@
 
     "generalPartnersPage": {
         "title": "You now need to tell us about the general partners",
-        "pageInformation": "If the partnership has more than one general partner, you'll add them one at a time."
+        "pageInformation": "If the partnership has more than one general partner, you'll add them one at a time.",
+        "disqualificationStatement" : "I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.",
+        "disqualificationStatementLegend" : "General partner - person - disqualification statement"
     },
 
     "govUk" : {

--- a/src/presentation/test/integration/registration/general-partners.test.ts
+++ b/src/presentation/test/integration/registration/general-partners.test.ts
@@ -26,7 +26,10 @@ describe("General Partners Page", () => {
     expect(res.text).toContain(
       `${cyTranslationText.generalPartnersPage.title} - ${cyTranslationText.serviceRegistration} - GOV.UK`
     );
-    testTranslations(res.text, cyTranslationText.generalPartnersPage);
+    testTranslations(res.text, cyTranslationText.generalPartnersPage, [
+      "disqualificationStatement",
+      "disqualificationStatementLegend"
+    ]);
   });
 
   it("should load the general partners page with English text", async () => {
@@ -37,7 +40,10 @@ describe("General Partners Page", () => {
     expect(res.text).toContain(
       `${enTranslationText.generalPartnersPage.title} - ${enTranslationText.serviceRegistration} - GOV.UK`
     );
-    testTranslations(res.text, enTranslationText.generalPartnersPage);
+    testTranslations(res.text, enTranslationText.generalPartnersPage, [
+      "disqualificationStatement",
+      "disqualificationStatementLegend"
+    ]);
   });
 
   it("should contain the proposed name - data from api", async () => {

--- a/src/presentation/test/integration/registration/generalPartner/add-general-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/add-general-partner-legal-entity.test.ts
@@ -50,6 +50,7 @@ describe("Add General Partner Legal Entity Page", () => {
         "dateMonth",
         "dateYear"
       ]);
+      expect(res.text).toContain("WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
     });
 
     it("should load the add general partner legal entity page with English text", async () => {
@@ -69,6 +70,7 @@ describe("Add General Partner Legal Entity Page", () => {
         "dateMonth",
         "dateYear"
       ]);
+      expect(res.text).toContain("I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
       expect(res.text).not.toContain("WELSH -");
     });
 

--- a/src/presentation/test/integration/registration/generalPartner/add-general-partner-person.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/add-general-partner-person.test.ts
@@ -46,6 +46,7 @@ describe("Add General Partner Person Page", () => {
         "limitedPartner",
         "dateEffectiveFrom"
       ]);
+      expect(res.text).toContain("WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
     });
 
     it("should load the add general partner page with English text", async () => {
@@ -61,6 +62,7 @@ describe("Add General Partner Person Page", () => {
         "limitedPartner",
         "dateEffectiveFrom"
       ]);
+      expect(res.text).toContain("I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
       expect(res.text).not.toContain("WELSH -");
     });
 

--- a/src/presentation/test/integration/transition/generalPartner/add-general-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/add-general-partner-legal-entity.test.ts
@@ -46,6 +46,7 @@ describe("Add General Partner Legal Entity Page", () => {
         `${cyTranslationText.addPartnerLegalEntityPage.generalPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
       testTranslations(res.text, cyTranslationText.addPartnerLegalEntityPage, ["limitedPartner", "errorMessages"]);
+      expect(res.text).not.toContain("WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
     });
 
     it("should load the add general partner legal entity page with English text", async () => {
@@ -57,6 +58,7 @@ describe("Add General Partner Legal Entity Page", () => {
         `${enTranslationText.addPartnerLegalEntityPage.generalPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
       testTranslations(res.text, enTranslationText.addPartnerLegalEntityPage, ["limitedPartner", "errorMessages"]);
+      expect(res.text).not.toContain("I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
       expect(res.text).not.toContain("WELSH -");
     });
 

--- a/src/presentation/test/integration/transition/generalPartner/add-general-partner-person.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/add-general-partner-person.test.ts
@@ -44,6 +44,7 @@ describe("Add General Partner Person Page", () => {
       expect(res.text).toContain(
         `${cyTranslationText.addPartnerPersonPage.generalPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
+      expect(res.text).not.toContain("WELSH - I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
       testTranslations(res.text, cyTranslationText.addPartnerPersonPage, ["errorMessages", "limitedPartner"]);
     });
 
@@ -56,6 +57,7 @@ describe("Add General Partner Person Page", () => {
         `${enTranslationText.addPartnerPersonPage.generalPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
       testTranslations(res.text, enTranslationText.addPartnerPersonPage, ["errorMessages", "limitedPartner"]);
+      expect(res.text).not.toContain("I confirm that the general partner is not disqualified under the directors disqualification legislation, as defined in the Limited Partnership Act 1907.");
       expect(res.text).not.toContain("WELSH -");
     });
 
@@ -160,7 +162,6 @@ describe("Add General Partner Person Page", () => {
       expect(res.text).toContain('id="previousNameNo" name="previousName" type="radio" value="false" checked');
       expect(res.text).toContain('<option value="Mongolian" selected>Mongolian</option>');
       expect(res.text).toContain('<option value="Uzbek" selected>Uzbek</option>');
-      expect(res.text).toContain('name="not_disqualified_statement_checked" type="checkbox" value="true"');
     });
   });
 
@@ -251,7 +252,6 @@ describe("Add General Partner Person Page", () => {
       expect(res.text).toContain("FORMER-NAMES");
       expect(res.text).toContain('<option value="Mongolian" selected>Mongolian</option>');
       expect(res.text).toContain('<option value="Uzbek" selected>Uzbek</option>');
-      expect(res.text).toContain('name="not_disqualified_statement_checked" type="checkbox" value="true"');
     });
 
     it("should send the general partner details and go to confirm ura address page if already saved", async () => {

--- a/src/presentation/test/integration/transition/generalPartner/general-partners.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/general-partners.test.ts
@@ -28,7 +28,10 @@ describe("General Partners Page", () => {
     expect(res.text).toContain(
       `${cyTranslationText.generalPartnersPage.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
     );
-    testTranslations(res.text, cyTranslationText.generalPartnersPage);
+    testTranslations(res.text, cyTranslationText.generalPartnersPage, [
+      "disqualificationStatement",
+      "disqualificationStatementLegend"
+    ]);
   });
 
   it("should load the general partners page with English text", async () => {
@@ -39,7 +42,10 @@ describe("General Partners Page", () => {
     expect(res.text).toContain(
       `${enTranslationText.generalPartnersPage.title} - ${enTranslationText.serviceTransition} - GOV.UK`
     );
-    testTranslations(res.text, enTranslationText.generalPartnersPage);
+    testTranslations(res.text, enTranslationText.generalPartnersPage, [
+      "disqualificationStatement",
+      "disqualificationStatementLegend"
+    ]);
   });
 
   it("should contain the proposed name - data from api", async () => {

--- a/src/views/add-general-partner-legal-entity.njk
+++ b/src/views/add-general-partner-legal-entity.njk
@@ -170,6 +170,8 @@
               }
             ]
           }) }}
+        {% else %}          
+          {% include "includes/disqualification-statement.njk" %}  
         {% endif %}
 
         {% include "includes/public-register-information.njk" %}

--- a/src/views/add-general-partner-person.njk
+++ b/src/views/add-general-partner-person.njk
@@ -203,31 +203,6 @@
         {% set nationalityFieldNameId = "nationality2" %}
         {% include "includes/nationalities.njk" %}
 
-        {{ govukCheckboxes({
-          id: "not_disqualified_statement_checked",
-          name: "not_disqualified_statement_checked",
-          value: props.data.generalPartner.data.not_disqualified_statement_checked,
-          errorMessage: props.errors.not_disqualified_statement_checked if props.errors,
-          classes: "govuk-!-margin-top-6",
-          fieldset: {
-            legend: {
-              text: i18n.addPartnerPersonPage.generalPartner.disqualificationStatementLegend,
-              isPageHeading: false,
-              classes: "govuk-visually-hidden"
-            }
-          },
-          items: [
-            {
-              value: "true",
-              text: i18n.addPartnerPersonPage.generalPartner.disqualificationStatement,
-              checked: props.data.generalPartner.data.not_disqualified_statement_checked,
-              attributes: {
-                required: true
-              }
-            }
-          ]
-        }) }}
-
         {% if journeyTypes.isTransition %}
           {{ govukDateInput({
             id: "date_effective_from",
@@ -276,6 +251,8 @@
               }
             ]
           }) }}
+        {% else %}        
+          {% include "includes/disqualification-statement.njk" %}  
         {% endif %}
 
         <div>

--- a/src/views/includes/disqualification-statement.njk
+++ b/src/views/includes/disqualification-statement.njk
@@ -1,0 +1,24 @@
+ {{ govukCheckboxes({
+    id: "not_disqualified_statement_checked",
+    name: "not_disqualified_statement_checked",
+    value: props.data.generalPartner.data.not_disqualified_statement_checked,
+    errorMessage: props.errors.not_disqualified_statement_checked if props.errors,
+    classes: "govuk-!-margin-top-6",
+    fieldset: {
+    legend: {
+        text: i18n.generalPartnersPage.disqualificationStatementLegend,
+        isPageHeading: false,
+        classes: "govuk-visually-hidden"
+      }
+    },
+    items: [
+      {
+        value: "true",
+        text: i18n.generalPartnersPage.disqualificationStatement,
+        checked: props.data.generalPartner.data.not_disqualified_statement_checked,
+        attributes: {
+          required: true
+        }
+      }
+    ]
+}) }}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-969

### Change description

- Refactored the template for disqualifications so that both general partner types can use the same code.
- Locales - added disqualification translations to a location for general partners neutral to person and legal entity.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.