### PR TITLE
LP-646 Govuk branding deployment issue - Don't delete package.json an…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ endif
 	cp -r ./package.json $(tmpdir)
 	cp -r ./package-lock.json $(tmpdir)
 	cd $(tmpdir) && npm ci --omit=dev --ignore-scripts
-	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .
 	rm -rf $(tmpdir)
 


### PR DESCRIPTION
…d lock file from Makefile

### JIRA link
https://companieshouse.atlassian.net/browse/LP-646


### Change description
Cidev deployment is failing because of the Govuk branding update. Solution suggested by other team (https://companieshouse.slack.com/archives/C092ZCNL2RF/p1752677719116779) is to remove the line that deletes package.json from the Makefile. The line is also deleting the lockfile so I will try not deleting that as well as it is linked to the package.json file.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.