### PR TITLE
LP-1025 Vary survey link in banner for Transition

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -494,8 +494,13 @@
     },
 
     "govUk" : {
+        "banner" : {
+          "tag": "WELSH - Beta",
+          "titleRegistration": "WELSH - This is a new service - your <a class='govuk-link' href='https://www.smartsurvey.co.uk/s/file-for-lp-fdbk/'>feedback</a> will help us to improve it.",
+          "titleTransition": "WELSH - This is a new service - your <a class='govuk-link' href='https://www.smartsurvey.co.uk/s/provideinfoaboutlp-fdbk/'>feedback</a> will help us to improve it."
+        },
         "error" : {
-            "title" : "WELSH - There is a problem"
+          "title" : "WELSH - There is a problem"
         }
     },
 

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -495,8 +495,13 @@
     },
 
     "govUk" : {
+        "banner" : {
+          "tag": "Beta",
+          "titleRegistration": "This is a new service - your <a class='govuk-link' href='https://www.smartsurvey.co.uk/s/file-for-lp-fdbk/'>feedback</a> will help us to improve it.",
+          "titleTransition": "This is a new service - your <a class='govuk-link' href='https://www.smartsurvey.co.uk/s/provideinfoaboutlp-fdbk/'>feedback</a> will help us to improve it."
+        },
         "error" : {
-            "title" : "There is a problem"
+          "title" : "There is a problem"
         }
     },
     

--- a/src/views/includes/phase_banner.njk
+++ b/src/views/includes/phase_banner.njk
@@ -1,6 +1,12 @@
+{% if journeyTypes.isRegistration %}
+  {% set bannerTitle = i18n.govUk.banner.titleRegistration %}
+{% else %}
+  {% set bannerTitle = i18n.govUk.banner.titleTransition %}
+{% endif %}
+
 {{ govukPhaseBanner({
   tag: {
-    text: "beta"
+    text: i18n.govUk.banner.tag
   },
-  html: 'This is a new service - your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/file-for-lp-fdbk/">feedback</a> will help us to improve it.'
+  html: bannerTitle
 }) }}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1025

### Change description

* Ensure that a different link is used for the feedback survey if user is on the transition journey
* Same link will be used for post-transition, until the correct link is provided
* 'Beta' tag name capitalised, in-line with GDS standard
* Phase banner text now changes if language is switched

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.