### PR TITLE
LP-986 Remove effective date from transition partner pages

### DIFF
--- a/src/presentation/test/integration/transition/generalPartner/add-general-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/add-general-partner-legal-entity.test.ts
@@ -41,7 +41,15 @@ describe("Add General Partner Legal Entity Page", () => {
       expect(res.text).toContain(
         `${cyTranslationText.addPartnerLegalEntityPage.generalPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, cyTranslationText.addPartnerLegalEntityPage, ["limitedPartner", "errorMessages"]);
+      testTranslations(res.text, cyTranslationText.addPartnerLegalEntityPage, [
+        "limitedPartner",
+        "errorMessages",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       testTranslations(res.text, cyTranslationText.generalPartnersPage, [
         "title",
         "pageInformation",
@@ -58,7 +66,15 @@ describe("Add General Partner Legal Entity Page", () => {
       expect(res.text).toContain(
         `${enTranslationText.addPartnerLegalEntityPage.generalPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, enTranslationText.addPartnerLegalEntityPage, ["limitedPartner", "errorMessages"]);
+      testTranslations(res.text, enTranslationText.addPartnerLegalEntityPage, [
+        "limitedPartner",
+        "errorMessages",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       testTranslations(res.text, enTranslationText.generalPartnersPage, [
         "title",
         "pageInformation",

--- a/src/presentation/test/integration/transition/generalPartner/add-general-partner-person.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/add-general-partner-person.test.ts
@@ -40,13 +40,21 @@ describe("Add General Partner Person Page", () => {
       expect(res.text).toContain(
         `${cyTranslationText.addPartnerPersonPage.generalPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
+      testTranslations(res.text, cyTranslationText.addPartnerPersonPage, [
+        "errorMessages",
+        "limitedPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       testTranslations(res.text, cyTranslationText.generalPartnersPage, [
         "title",
         "pageInformation",
         "disqualificationStatement",
         "disqualificationStatementLegend"
       ]);
-      testTranslations(res.text, cyTranslationText.addPartnerPersonPage, ["errorMessages", "limitedPartner"]);
     });
 
     it("should load the add general partner page with English text", async () => {
@@ -57,7 +65,15 @@ describe("Add General Partner Person Page", () => {
       expect(res.text).toContain(
         `${enTranslationText.addPartnerPersonPage.generalPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, enTranslationText.addPartnerPersonPage, ["errorMessages", "limitedPartner"]);
+      testTranslations(res.text, enTranslationText.addPartnerPersonPage, [
+        "errorMessages",
+        "limitedPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       testTranslations(res.text, enTranslationText.generalPartnersPage, [
         "title",
         "pageInformation",

--- a/src/presentation/test/integration/transition/limitedPartner/add-limited-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/add-limited-partner-legal-entity.test.ts
@@ -39,7 +39,15 @@ describe("Add Limited Partner Legal Entity Page", () => {
       expect(res.text).toContain(
         `${cyTranslationText.addPartnerLegalEntityPage.limitedPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, cyTranslationText.addPartnerLegalEntityPage, ["errorMessages", "generalPartner"]);
+      testTranslations(res.text, cyTranslationText.addPartnerLegalEntityPage, [
+        "errorMessages",
+        "generalPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
     });
 
     it("should load the add limited partner page with English text", async () => {
@@ -50,7 +58,15 @@ describe("Add Limited Partner Legal Entity Page", () => {
       expect(res.text).toContain(
         `${enTranslationText.addPartnerLegalEntityPage.limitedPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, enTranslationText.addPartnerLegalEntityPage, ["errorMessages", "generalPartner"]);
+      testTranslations(res.text, enTranslationText.addPartnerLegalEntityPage, [
+        "errorMessages",
+        "generalPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       expect(res.text).not.toContain("WELSH -");
     });
 

--- a/src/presentation/test/integration/transition/limitedPartner/add-limited-partner-person.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/add-limited-partner-person.test.ts
@@ -42,7 +42,15 @@ describe("Add Limited Partner Person Page", () => {
       expect(res.text).toContain(
         `${cyTranslationText.addPartnerPersonPage.limitedPartner.title} - ${cyTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, cyTranslationText.addPartnerPersonPage, ["errorMessages", "generalPartner"]);
+      testTranslations(res.text, cyTranslationText.addPartnerPersonPage, [
+        "errorMessages",
+        "generalPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
 
       expect(res.text).not.toContain(enTranslationText.capitalContribution.title);
     });
@@ -59,7 +67,15 @@ describe("Add Limited Partner Person Page", () => {
       expect(res.text).toContain(
         `${enTranslationText.addPartnerPersonPage.limitedPartner.title} - ${enTranslationText.serviceTransition} - GOV.UK`
       );
-      testTranslations(res.text, enTranslationText.addPartnerPersonPage, ["errorMessages", "generalPartner"]);
+      testTranslations(res.text, enTranslationText.addPartnerPersonPage, [
+        "errorMessages",
+        "generalPartner",
+        "dateEffectiveFrom",
+        "dateHint",
+        "dateDay",
+        "dateMonth",
+        "dateYear"
+      ]);
       expect(res.text).not.toContain("WELSH -");
 
       expect(res.text).not.toContain(enTranslationText.capitalContribution.title);

--- a/src/views/add-general-partner-legal-entity.njk
+++ b/src/views/add-general-partner-legal-entity.njk
@@ -127,7 +127,7 @@
           }
         }) }}
 
-        {% if journeyTypes.isTransition or journeyTypes.isPostTransition %}
+        {% if journeyTypes.isPostTransition %}
           {{ govukDateInput({
             id: "date_effective_from",
             namePrefix: "date_effective_from",

--- a/src/views/add-general-partner-person.njk
+++ b/src/views/add-general-partner-person.njk
@@ -206,7 +206,7 @@
           {% include "includes/disqualification-statement.njk" %}  
         {% endif %}
 
-        {% if not journeyTypes.isRegistration%}
+        {% if journeyTypes.isPostTransition %}
           {{ govukDateInput({
             id: "date_effective_from",
             namePrefix: "date_effective_from",

--- a/src/views/add-limited-partner-legal-entity.njk
+++ b/src/views/add-limited-partner-legal-entity.njk
@@ -132,7 +132,7 @@
           {% include "includes/capital-contribution.njk" %}
         {% endif %}
 
-        {% if not journeyTypes.isRegistration %}
+        {% if journeyTypes.isPostTransition %}
           {{ govukDateInput({
             id: "date_effective_from",
             namePrefix: "date_effective_from",

--- a/src/views/add-limited-partner-person.njk
+++ b/src/views/add-limited-partner-person.njk
@@ -209,7 +209,7 @@
           {% include "includes/capital-contribution.njk" %}
         {% endif %} 
 
-        {% if not journeyTypes.isRegistration %}
+        {% if journeyTypes.isPostTransition %}
           {{ govukDateInput({
             id: "date_effective_from",
             namePrefix: "date_effective_from",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-986

### Change description

Removed effective date fields for transition pages by changing the condition to test exclusively for post transition on the template for each partner page.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.