### PR TITLE
LP-912 Fix address not replaying for partners

### DIFF
--- a/src/presentation/controller/postTransition/LimitedPartnershipController.ts
+++ b/src/presentation/controller/postTransition/LimitedPartnershipController.ts
@@ -185,7 +185,6 @@ class LimitedPartnershipController extends AbstractController {
           super.makeProps(pageRouting, { limitedPartnership }, null)
         );
       } catch (error) {
-        console.log(error);
         next(error);
       }
     };

--- a/src/views/enter-general-partner-correspondence-address.njk
+++ b/src/views/enter-general-partner-correspondence-address.njk
@@ -22,8 +22,8 @@
   {% set address = props.data.address %}
 {% elif props.data.cache[correspondenceAddressKey] %}
   {% set address = props.data.cache[correspondenceAddressKey] %}
-{% elif props.data.limitedPartnership.data.service_address %}
-  {% set address = props.data.service_address %}
+{% elif props.data.generalPartner.data.service_address %}
+  {% set address = props.data.generalPartner.data.service_address %}
 {% else %}
   {% set address = {} %}
 {% endif %}

--- a/src/views/enter-general-partner-principal-office-address.njk
+++ b/src/views/enter-general-partner-principal-office-address.njk
@@ -23,8 +23,8 @@
   {% set address = props.data.address %}
 {% elif props.data.cache[principalOfficeAddressKey] %}
   {% set address = props.data.cache[principalOfficeAddressKey] %}
-{% elif props.data.limitedPartnership.data.principal_office_address %}
-  {% set address = props.data.principal_office_address %}
+{% elif props.data.generalPartner.data.principal_office_address %}
+  {% set address = props.data.generalPartner.data.principal_office_address %}
 {% else %}
   {% set address = {} %}
 {% endif %}

--- a/src/views/enter-general-partner-usual-residential-address.njk
+++ b/src/views/enter-general-partner-usual-residential-address.njk
@@ -22,8 +22,8 @@
   {% set address = props.data.address %}
 {% elif props.data.cache[usualResidentialAddressKey] %}
   {% set address = props.data.cache[usualResidentialAddressKey] %}
-{% elif props.data.limitedPartnership.data.usual_residential_address %}
-  {% set address = props.data.usual_residential_address %}
+{% elif props.data.generalPartner.data.usual_residential_address %}
+  {% set address = props.data.generalPartner.data.usual_residential_address %}
 {% else %}
   {% set address = {} %}
 {% endif %}

--- a/src/views/enter-limited-partner-principal-office-address.njk
+++ b/src/views/enter-limited-partner-principal-office-address.njk
@@ -22,8 +22,8 @@
   {% set address = props.data.address %}
 {% elif props.data.cache[principalOfficeAddressKey] %}
   {% set address = props.data.cache[principalOfficeAddressKey] %}
-{% elif props.data.limitedPartnership.data.principal_office_address %}
-  {% set address = props.data.principal_office_address %}
+{% elif props.data.limitedPartner.data.principal_office_address %}
+  {% set address = props.data.limitedPartner.data.principal_office_address %}
 {% else %}
   {% set address = {} %}
 {% endif %}

--- a/src/views/enter-limited-partner-usual-residential-address.njk
+++ b/src/views/enter-limited-partner-usual-residential-address.njk
@@ -22,8 +22,8 @@
   {% set address = props.data.address %}
 {% elif props.data.cache[usualResidentialAddressKey] %}
   {% set address = props.data.cache[usualResidentialAddressKey] %}
-{% elif props.data.limitedPartnership.data.usual_residential_address %}
-  {% set address = props.data.usual_residential_address %}
+{% elif props.data.limitedPartner.data.usual_residential_address %}
+  {% set address = props.data.limitedPartner.data.usual_residential_address %}
 {% else %}
   {% set address = {} %}
 {% endif %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-912


### Change description
Fix partners' addresses not replaying correctly when using the 'change' link by correcting data path references in Nunjucks templates.

- Corrected data path references from limitedPartnership to appropriate partner types (limitedPartner and generalPartner)
- Fixed address field access paths to use the correct nested data structure
- Removed debugging console.log statement from controller


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.