### PR TITLE
LP-1157 Fix PPoB blank entry for screen reader

### DIFF
--- a/src/views/enter-principal-place-of-business-address.njk
+++ b/src/views/enter-principal-place-of-business-address.njk
@@ -14,7 +14,6 @@
 {% set pageTitle = i18n.address.enterAddress.principalPlaceOfBusinessAddress.title %}
 {% set titleHint1 = i18n.address.enterAddress.principalPlaceOfBusinessAddress.titleHint1 %}
 {% set titleHint2 = i18n.address.enterAddress.principalPlaceOfBusinessAddress.titleHint2 %}
-{% set titleHint3 = i18n.address.enterAddress.principalPlaceOfBusinessAddress.titleHint3 %}
 {% set publicRegisterInformationLine1 = i18n.address.enterAddress.principalPlaceOfBusinessAddress.publicInformationLine1 %}
 
 {% block content %}
@@ -32,8 +31,6 @@
 
         <p class="govuk-hint">{{ titleHint1 }}</p>
         <p class="govuk-hint">{{ titleHint2 }}</p>
-        <p class="govuk-hint">{{ titleHint3 }}</p>
-
         <br>
       </fieldset>
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1157


### Change description
Fixes an accessibility issue where screen readers were encountering a blank line on the Principal Place of Business manual entry screen due to an empty titleHint3 field.

- Removes unused titleHint3 variable declaration and corresponding HTML element
- Eliminates unnecessary empty paragraph element that was causing screen reader issues


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.