### PR TITLE
LP-1821 Set the PSC type when adding new PSCs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.333",
+        "@companieshouse/api-sdk-node": "^2.0.335",
         "@companieshouse/ch-node-utils": "^2.1.11",
         "@companieshouse/node-session-handler": "^5.2.8",
         "@companieshouse/structured-logging-node": "^2.0.4",
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.333",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.333.tgz",
-      "integrity": "sha512-z7pRBmUl7zP2KqUWZxtjy2ASMwi62FGnptTrjjkSdUZ9GPOLZxuj0jB4EtOu6b0ylnj7rB9cSXKvEiTpYGTqyA==",
+      "version": "2.0.335",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.335.tgz",
+      "integrity": "sha512-t83WcWIP9uVUlwNAoHnfdQfOCn9jpP//gkd3VxlNdorBqFrvE/X1KcsX35M69gzwOMiJDOIcIadVDHxowS7O0A==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://github.com/companieshouse/limited-partnerships-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.333",
+    "@companieshouse/api-sdk-node": "^2.0.335",
     "@companieshouse/ch-node-utils": "^2.1.11",
     "@companieshouse/node-session-handler": "^5.2.8",
     "@companieshouse/structured-logging-node": "^2.0.4",

--- a/src/application/service/PersonWithSignificantControlService.ts
+++ b/src/application/service/PersonWithSignificantControlService.ts
@@ -24,6 +24,7 @@ class PersonWithSignificantControlService {
     errors?: any;
   }> {
     try {
+      console.log(data);
       const personWithSignificantControlId =
         await this.personWithSignificantControlGateway.createPersonWithSignificantControl(opt, transactionId, data);
 

--- a/src/application/service/PersonWithSignificantControlService.ts
+++ b/src/application/service/PersonWithSignificantControlService.ts
@@ -24,7 +24,6 @@ class PersonWithSignificantControlService {
     errors?: any;
   }> {
     try {
-      console.log(data);
       const personWithSignificantControlId =
         await this.personWithSignificantControlGateway.createPersonWithSignificantControl(opt, transactionId, data);
 

--- a/src/presentation/controller/registration/PersonWithSignificantControlController.ts
+++ b/src/presentation/controller/registration/PersonWithSignificantControlController.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { LimitedPartnership } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+import { LimitedPartnership, PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 
 import AbstractController from "../AbstractController";
 import UIErrors from "../../../domain/entities/UIErrors";
@@ -129,9 +129,9 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
   private getAddPersonWithSignificantControlRedirectUrl(request, ids: Ids) {
     let url = ADD_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_URL;
 
-    if (request.body.parameter === "relevant_legal_entity") {
+    if (request.body.parameter === PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY) {
       url = ADD_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_URL;
-    } else if (request.body.parameter === "other_registrable_person") {
+    } else if (request.body.parameter === PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON) {
       url = ADD_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_URL;
     }
 

--- a/src/presentation/test/integration/registration/personWithSignificantControl/add-other-registrable-person.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/add-other-registrable-person.test.ts
@@ -22,6 +22,7 @@ import TransactionBuilder from "../../../builder/TransactionBuilder";
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSignificantControl";
 import TransactionPersonWithSignificantControl from "../../../../../domain/entities/TransactionPersonWithSignificantControl";
+import { PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 describe("Add Person With Significant Control Other registrable person Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
@@ -104,6 +105,7 @@ describe("Add Person With Significant Control Other registrable person Page", ()
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlOtherRegistrablePerson,
+          type: PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON,
           ...personWithSignificantControl.data
         });
 
@@ -111,6 +113,9 @@ describe("Add Person With Significant Control Other registrable person Page", ()
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
 
       expect(appDevDependencies.personWithSignificantControlGateway.personsWithSignificantControl).toHaveLength(1);
+      expect(appDevDependencies.personWithSignificantControlGateway.personsWithSignificantControl[0].data.type).toEqual(
+        PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON
+      );
     });
 
     it("should return a validation error when invalid data is entered", async () => {
@@ -126,6 +131,7 @@ describe("Add Person With Significant Control Other registrable person Page", ()
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlOtherRegistrablePerson,
+          type: PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON,
           ...personWithSignificantControl.data,
           legal_entity_name: "INVALID-CHARACTERS"
         });
@@ -154,6 +160,7 @@ describe("Add Person With Significant Control Other registrable person Page", ()
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlOtherRegistrablePerson,
+          type: PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON,
           ...personWithSignificantControl.data,
           legal_entity_name: "legal entity name updated"
         });
@@ -177,6 +184,7 @@ describe("Add Person With Significant Control Other registrable person Page", ()
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlOtherRegistrablePerson,
+          type: PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON,
           ...personWithSignificantControl.data,
           legal_entity_name: "INVALID-CHARACTERS"
         });

--- a/src/presentation/test/integration/registration/personWithSignificantControl/add-relevant-legal-entity.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/add-relevant-legal-entity.test.ts
@@ -22,6 +22,7 @@ import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSign
 import TransactionBuilder from "../../../builder/TransactionBuilder";
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import TransactionPersonWithSignificantControl from "../../../../../domain/entities/TransactionPersonWithSignificantControl";
+import { PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 describe("Add Person With Significant Control Relevant Legal Entity Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
@@ -104,6 +105,7 @@ describe("Add Person With Significant Control Relevant Legal Entity Page", () =>
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlRelevantLegalEntity,
+          type: PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY,
           ...personWithSignificantControl.data
         });
 
@@ -111,6 +113,9 @@ describe("Add Person With Significant Control Relevant Legal Entity Page", () =>
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
 
       expect(appDevDependencies.personWithSignificantControlGateway.personsWithSignificantControl).toHaveLength(1);
+      expect(appDevDependencies.personWithSignificantControlGateway.personsWithSignificantControl[0].data.type).toEqual(
+        PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY
+      );
     });
 
     it("should return a validation error when invalid data is entered", async () => {
@@ -126,6 +131,7 @@ describe("Add Person With Significant Control Relevant Legal Entity Page", () =>
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlRelevantLegalEntity,
+          type: PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY,
           ...personWithSignificantControl.data,
           legal_entity_name: "INVALID-CHARACTERS"
         });
@@ -154,6 +160,7 @@ describe("Add Person With Significant Control Relevant Legal Entity Page", () =>
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlRelevantLegalEntity,
+          type: PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY,
           ...personWithSignificantControl.data,
           legal_entity_name: "legal entity name updated"
         });
@@ -177,6 +184,7 @@ describe("Add Person With Significant Control Relevant Legal Entity Page", () =>
         .post(URL)
         .send({
           pageType: RegistrationPageType.addPersonWithSignificantControlRelevantLegalEntity,
+          type: PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY,
           ...personWithSignificantControl.data,
           legal_entity_name: "INVALID-CHARACTERS"
         });

--- a/src/presentation/test/integration/registration/personWithSignificantControl/which-type.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/which-type.test.ts
@@ -19,6 +19,7 @@ import {
   PERSON_WITH_SIGNIFICANT_CONTROL_CHOICE_URL,
   WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL
 } from "../../../../controller/registration/url";
+import { PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 describe("Which type Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
@@ -60,12 +61,12 @@ describe("Which type Page", () => {
     ["add individual person", "individual_person", ADD_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_URL],
     [
       "add relevant legal entity",
-      "relevant_legal_entity",
+      PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY,
       ADD_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_URL
     ],
     [
       "add other registrable person",
-      "other_registrable_person",
+      PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON,
       ADD_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_URL
     ]
   ])(

--- a/src/views/add-person-with-significant-control-other-registrable-person.njk
+++ b/src/views/add-person-with-significant-control-other-registrable-person.njk
@@ -17,6 +17,8 @@
                 <input type="hidden" name="pageType" value={{ props.pageType }}>
                 {% include "includes/csrf_token.njk" %}
 
+                <input type="hidden" name="type" value="OTHER_REGISTRABLE_PERSON">
+
                 {% set legalEntityName = i18n.personWithSignificantControl.addPersonWithSignificantControl.addOtherRegistrablePerson.legalEntityName %}
                 {% include "pages/personWithSignificantControl/add-person-with-significant-control.njk" %}
 

--- a/src/views/add-person-with-significant-control-relevant-legal-entity.njk
+++ b/src/views/add-person-with-significant-control-relevant-legal-entity.njk
@@ -17,6 +17,8 @@
                 <input type="hidden" name="pageType" value={{ props.pageType }}>
                 {% include "includes/csrf_token.njk" %}
 
+                <input type="hidden" name="type" value="RELEVANT_LEGAL_ENTITY">
+
                 {% set legalEntityName = i18n.personWithSignificantControl.addPersonWithSignificantControl.addRelevantLegalEntity.legalEntityName %}
                 {% include "pages/personWithSignificantControl/add-person-with-significant-control.njk" %}
 

--- a/src/views/person-with-significant-control-choice.njk
+++ b/src/views/person-with-significant-control-choice.njk
@@ -29,15 +29,15 @@
           },
           items: [
             {
-              value: "individual_person",
+              value: "INDIVIDUAL_PERSON",
               text: i18n.personWithSignificantControl.whichTypePage.addIndividualPerson
             },
             {
-              value: "relevant_legal_entity",
+              value: "RELEVANT_LEGAL_ENTITY",
               text: i18n.personWithSignificantControl.whichTypePage.addRelevantLegalEntity
             },
             {
-              value: "other_registrable_person",
+              value: "OTHER_REGISTRABLE_PERSON",
               text: i18n.personWithSignificantControl.whichTypePage.addOtherRegistrablePerson
             }
           ]


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1821


### Change description
Set the PSC type when adding new PSCs


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.