### PR TITLE
LP-1734 Remove empty strings on PSC update - causes issues with Api validation

### DIFF
--- a/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
+++ b/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
@@ -65,11 +65,10 @@ export default class PersonWithSignificantControlGateway implements IPersonWithS
     personWithSignificantControlId: string,
     data: Partial<PersonWithSignificantControl>
   ): Promise<void> {
-    data = removeEmptyStringValues(data, ["legal_entity_register_name", "registered_company_number"]);
     const apiCall = {
       service: SDK_LIMITED_PARTNERSHIP_SERVICE,
       method: "patchPersonWithSignificantControl",
-      args: [transactionId, personWithSignificantControlId, data]
+      args: [transactionId, personWithSignificantControlId, removeEmptyStringValues(data, ["legal_entity_register_name", "registered_company_number"])]
     };
 
     const response = await makeApiCallWithRetry<Resource<void>>(opt, apiCall);

--- a/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
+++ b/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
@@ -65,7 +65,7 @@ export default class PersonWithSignificantControlGateway implements IPersonWithS
     personWithSignificantControlId: string,
     data: Partial<PersonWithSignificantControl>
   ): Promise<void> {
-    data = removeEmptyStringValues(data);
+    data = removeEmptyStringValues(data, ["legal_entity_register_name", "registered_company_number"]);
     const apiCall = {
       service: SDK_LIMITED_PARTNERSHIP_SERVICE,
       method: "patchPersonWithSignificantControl",

--- a/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
+++ b/src/infrastructure/gateway/personWithSignificantControl/PersonWithSignificantControlGateway.ts
@@ -65,6 +65,7 @@ export default class PersonWithSignificantControlGateway implements IPersonWithS
     personWithSignificantControlId: string,
     data: Partial<PersonWithSignificantControl>
   ): Promise<void> {
+    data = removeEmptyStringValues(data);
     const apiCall = {
       service: SDK_LIMITED_PARTNERSHIP_SERVICE,
       method: "patchPersonWithSignificantControl",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1734


### Change description
Make sure we remove empty strings when submitting the updated PSC data (the same thing is already done on the data sent for a create)
It was causing validation issues in API, specifically the location country was getting mapped to UNKNOWN when not supplied and failing validation.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.