### PR TITLE
LP-1800: Update capital contribution content and layout

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -97,18 +97,16 @@
     },
 
     "capitalContribution" : {
-        "title" : "WELSH - What is their total capital contribution?",
-        "currencyTypeLabel": "WELSH - Contribution currency type",
-        "valueLabel": "WELSH - Contribution currency value",
+        "title" : "WELSH - What is this partner's total capital contribution?",
+        "currencyTypeLabel": "WELSH - Select the currency",
+        "valueLabel": "WELSH - Enter the total value",
         "hint" : "WELSH - This is the total value of all monetary and non-monetary contributions",
-        "amountHint": "WELSH - Enter the value, for example:",
-        "amountMinHint": "WELSH - if they contributed £0.01 enter 0.01",
-        "amountMaxHint": "WELSH - if they contributed $25,000 enter 25000.00",
+        "amountHint": "WELSH - For example, if it was £25 enter 25.00",
         "compositionTitle" : "WELSH - What is this total value made up of?",
         "compositionHint" : "WELSH - Select all that apply",
         "money" : "WELSH - Money",
         "landOrProperty" : "WELSH - Land or property",
-        "shares" : "WELSH - Shares",
+        "shares" : "WELSH - Shares or interests in other partnerships",
         "anyOtherAsset" : "WELSH - Any other asset",
         "servicesOrGoods" : "WELSH - Services or goods"
      },

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -97,18 +97,16 @@
     },
 
     "capitalContribution" : {
-       "title" : "What is their total capital contribution?",
-       "currencyTypeLabel": "Contribution currency type",
-       "valueLabel": "Contribution currency value",
+       "title" : "What is this partner's total capital contribution?",
+       "currencyTypeLabel": "Select the currency",
+       "valueLabel": "Enter the total value",
        "hint" : "This is the total value of all monetary and non-monetary contributions",
-       "amountHint": "Enter the value, for example:",
-       "amountMinHint": "if they contributed £0.01 enter 0.01",
-       "amountMaxHint": "if they contributed $25,000 enter 25000.00",
+       "amountHint": "For example, if it was £25 enter 25.00",
        "compositionTitle" : "What is this total value made up of?",
        "compositionHint" : "Select all that apply",
        "money" : "Money",
        "landOrProperty" : "Land or property",
-       "shares" : "Shares",
+       "shares" : "Shares or interests in other partnerships",
        "servicesOrGoods" : "Services or goods",
        "anyOtherAsset" : "Any other asset"
     },

--- a/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-legal-entity.test.ts
@@ -71,7 +71,7 @@ describe("Add Limited Partner Legal Entity Page", () => {
         ]);
 
         if (expectCapitalContributionText) {
-          expect(res.text).toContain(toEscapedHtml(i18n.capitalContribution.title));
+          testTranslations(res.text, i18n.capitalContribution);
         } else {
           expect(res.text).not.toContain(toEscapedHtml(i18n.capitalContribution.title));
         }

--- a/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-legal-entity.test.ts
@@ -7,7 +7,7 @@ import cyTranslationText from "../../../../../../locales/cy/translations.json";
 
 import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
+import { countOccurrences, getUrl, setLocalesEnabled, testTranslations, toEscapedHtml } from "../../../utils";
 import { ApiErrors } from "../../../../../domain/entities/UIErrors";
 
 import PostTransitionPageType from "../../../../controller/postTransition/pageType";
@@ -71,9 +71,9 @@ describe("Add Limited Partner Legal Entity Page", () => {
         ]);
 
         if (expectCapitalContributionText) {
-          expect(res.text).toContain(i18n.capitalContribution.title);
+          expect(res.text).toContain(toEscapedHtml(i18n.capitalContribution.title));
         } else {
-          expect(res.text).not.toContain(i18n.capitalContribution.title);
+          expect(res.text).not.toContain(toEscapedHtml(i18n.capitalContribution.title));
         }
 
         if (lang !== "cy") {

--- a/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-person.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-person.test.ts
@@ -9,7 +9,7 @@ import cyTranslationText from "../../../../../../locales/cy/translations.json";
 import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 import { ApiErrors } from "../../../../../domain/entities/UIErrors";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
+import { countOccurrences, getUrl, setLocalesEnabled, testTranslations, toEscapedHtml } from "../../../utils";
 
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import PostTransitionPageType from "../../../../controller/postTransition/pageType";
@@ -76,9 +76,9 @@ describe("Add Limited Partner Person Page", () => {
         ]);
 
         if (expectCapitalContributionText) {
-          expect(res.text).toContain(i18n.capitalContribution.title);
+          expect(res.text).toContain(toEscapedHtml(i18n.capitalContribution.title));
         } else {
-          expect(res.text).not.toContain(i18n.capitalContribution.title);
+          expect(res.text).not.toContain(toEscapedHtml(i18n.capitalContribution.title));
         }
 
         if (lang !== "cy") {

--- a/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-person.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/add-limited-partner-person.test.ts
@@ -76,7 +76,7 @@ describe("Add Limited Partner Person Page", () => {
         ]);
 
         if (expectCapitalContributionText) {
-          expect(res.text).toContain(toEscapedHtml(i18n.capitalContribution.title));
+          testTranslations(res.text, i18n.capitalContribution);
         } else {
           expect(res.text).not.toContain(toEscapedHtml(i18n.capitalContribution.title));
         }

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -387,7 +387,7 @@ describe("Check Your Answers Page", () => {
 
     expect(res.status).toBe(200);
     expect(res.text).toContain("5.00 Pound Sterling (GBP)");
-    expect(res.text).toContain("Shares / Any other asset");
+    expect(res.text).toContain("Shares or interests in other partnerships / Any other asset");
   });
 
   it("should load the check your answers page with capital contribution data in Welsh", async () => {
@@ -405,7 +405,7 @@ describe("Check Your Answers Page", () => {
 
     expect(res.status).toBe(200);
     expect(res.text).toContain("5.00 WELSH - Pound Sterling (GBP)");
-    expect(res.text).toContain("WELSH - Shares / WELSH - Any other asset");
+    expect(res.text).toContain("WELSH - Shares or interests in other partnerships / WELSH - Any other asset");
   });
 
   describe("PSC statement on CYA page", () => {

--- a/src/views/includes/capital-contribution.njk
+++ b/src/views/includes/capital-contribution.njk
@@ -1,9 +1,11 @@
 {% if (partnershipType == "LP") or (partnershipType == "SLP") %}
-    
-  <h2 class="govuk-heading-m">{{ i18n.capitalContribution.title}}</h2>
+
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+  <h2 class="govuk-heading-s">{{ i18n.capitalContribution.title}}</h2>
 
   <p class="govuk-hint">{{ i18n.capitalContribution.hint }}</p>
- 
+
   {% set currencyField = props.data.limitedPartner.data.contribution_currency_type %}
   {% include "includes/currencies.njk" %}
 
@@ -12,23 +14,15 @@
     {% set contribution_sub_types = props.data.limitedPartner.data.contribution_sub_types %}
   {% endif %}
 
-  {% set hintHtml -%}
-    <p class="govuk-body">{{ i18n.capitalContribution.amountHint }}</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li class="govuk-body">{{ i18n.capitalContribution.amountMinHint }}</li>
-      <li class="govuk-body">{{ i18n.capitalContribution.amountMaxHint }}</li>       
-    </ul>
-  {%- endset %}
-
-  {{ govukInput({ 
+  {{ govukInput({
     label: {
       text: i18n.capitalContribution.valueLabel,
-      classes: "govuk-visually-hidden",
+      classes: "govuk-label--m",
       isPageHeading: false
      },
     hint: {
-      html: hintHtml
-    },  
+      text: i18n.capitalContribution.amountHint
+    },
     classes: "govuk-input--width-10",
     id: "contribution_currency_value",
     name: "contribution_currency_value",
@@ -84,13 +78,15 @@
         } 
       },
       {
-        value: "ANY_OTHER_ASSET",        
+        value: "ANY_OTHER_ASSET",
         text: i18n.capitalContribution.anyOtherAsset,
         checked: true if "ANY_OTHER_ASSET" in contribution_sub_types else false,
         attributes: {
           "data-event-id": "capital_contribution_anyOtherAsset"
-        } 
+        }
       }
     ]
   }) }}
+
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 {% endif %}

--- a/src/views/includes/currencies.njk
+++ b/src/views/includes/currencies.njk
@@ -178,7 +178,7 @@
   name: "contribution_currency_type",
   label: {
     text: i18n.capitalContribution.currencyTypeLabel,
-    classes: "govuk-visually-hidden",
+    classes: "govuk-label--m",
     isPageHeading: false
   },
   errorMessage: props.errors.contribution_currency_type if props.errors.contribution_currency_type,


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1800

### Change description

Update the capital contribution section on add limited partner pages (person and legal entity) for registration and post-transition journeys:

- Update translation strings: new title, hint text, and "Shares or interests in other partnerships" label
- Make currency and value input labels visible (remove `govuk-visually-hidden`, use `govuk-label--m`)
- Demote section heading from `govuk-heading-m` to `govuk-heading-s`
- Replace bullet-list hint with single-line hint text
- Add horizontal rules above and below the capital contribution section
- Fix test assertions to handle HTML-escaped apostrophe in new title
- Update hardcoded "Shares" string in check-your-answers test

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.