### PR TITLE
Feature/psc/lp 1825 save and resume flow rle and orp

### DIFF
--- a/src/presentation/controller/registration/PersonWithSignificantControlController.ts
+++ b/src/presentation/controller/registration/PersonWithSignificantControlController.ts
@@ -16,6 +16,7 @@ import {
   ADD_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_URL,
   CHECK_YOUR_ANSWERS_URL,
   PERSON_WITH_SIGNIFICANT_CONTROL_CHOICE_URL,
+  REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL,
   TELL_US_ABOUT_PSC_URL
 } from "./url";
 
@@ -152,7 +153,7 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
           return await this.renderWithPartnershipAndErrors(request, response, result.errors);
         }
 
-        pageRouting.nextUrl = this.handlePersonWithSignficantControlRequiredConditionalNextUrl(request);
+        pageRouting.nextUrl = await this.handlePersonWithSignficantControlRequiredConditionalNextUrl(request);
 
         response.redirect(pageRouting.nextUrl);
       } catch (error) {
@@ -377,10 +378,17 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
     );
   }
 
-  private handlePersonWithSignficantControlRequiredConditionalNextUrl(request: Request) {
+  private async handlePersonWithSignficantControlRequiredConditionalNextUrl(request: Request) {
     const ids = super.extractIds(request);
+    const { tokens } = super.extract(request);
+    const result = await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, ids.transactionId);
+
     if (request.body.has_person_with_significant_control === "true") {
-      return super.insertIdsInUrl(PERSON_WITH_SIGNIFICANT_CONTROL_CHOICE_URL, ids, request.url);
+      if (result.personsWithSignificantControl.length > 0) {
+        return super.insertIdsInUrl(REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL, ids, request.url);
+      } else {
+        return super.insertIdsInUrl(PERSON_WITH_SIGNIFICANT_CONTROL_CHOICE_URL, ids, request.url);
+      }
     } else {
       return super.insertIdsInUrl(CHECK_YOUR_ANSWERS_URL, ids, request.url);
     }

--- a/src/presentation/controller/registration/PersonWithSignificantControlController.ts
+++ b/src/presentation/controller/registration/PersonWithSignificantControlController.ts
@@ -19,6 +19,8 @@ import {
   REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL,
   TELL_US_ABOUT_PSC_URL
 } from "./url";
+import { CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL, CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL } from "../addressLookUp/url/registration";
+import { PageRouting } from "../PageRouting";
 
 class PersonWithSignificantControlRegistrationController extends AbstractController {
   constructor(
@@ -282,6 +284,8 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
           );
         }
 
+        await this.handleNatureOfControlRedirection(request, pageRouting);
+
         response.redirect(pageRouting.nextUrl);
       } catch (error) {
         next(error);
@@ -481,6 +485,28 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
     const redirectUrl = reviewPageUrlMap.get(addAnotherPersonWithSignificantControl) ?? "";
 
     return super.insertIdsInUrl(redirectUrl, ids, request.url);
+  }
+
+  private async handleNatureOfControlRedirection(request: Request, pageRouting: PageRouting) {
+    const { ids, tokens, pageType } = super.extract(request);
+
+    const result = await this.personWithSignificantControlService.getPersonWithSignificantControl(
+      tokens,
+      ids.transactionId,
+      ids.personWithSignificantControlId
+    );
+
+    if (pageType === RegistrationPageType.whichTypeOfNatureOfControlRelevantLegalEntity &&
+      result?.data?.principal_office_address?.address_line_1) {
+
+      pageRouting.nextUrl = super.insertIdsInUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL, ids, request.url);
+    }
+
+    if (pageType === RegistrationPageType.whichTypeOfNatureOfControlOtherRegistrablePerson &&
+      result?.data?.principal_office_address?.address_line_1) {
+
+      pageRouting.nextUrl = super.insertIdsInUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL, ids, request.url);
+    }
   }
 }
 

--- a/src/presentation/controller/registration/PersonWithSignificantControlController.ts
+++ b/src/presentation/controller/registration/PersonWithSignificantControlController.ts
@@ -385,9 +385,10 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
   private async handlePersonWithSignficantControlRequiredConditionalNextUrl(request: Request) {
     const ids = super.extractIds(request);
     const { tokens } = super.extract(request);
-    const result = await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, ids.transactionId);
 
     if (request.body.has_person_with_significant_control === "true") {
+      const result = await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, ids.transactionId);
+
       if (result.personsWithSignificantControl.length > 0) {
         return super.insertIdsInUrl(REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL, ids, request.url);
       } else {

--- a/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-other-registrable-person.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-other-registrable-person.test.ts
@@ -9,13 +9,14 @@ import { appDevDependencies } from "../../../../../config/dev-dependencies";
 import { WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL } from "../../../../controller/registration/url";
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
-import { TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../controller/addressLookUp/url/registration";
+import { CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL, TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../controller/addressLookUp/url/registration";
 import RegistrationPageType from "../../../../controller/registration/PageType";
 import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSignificantControlBuilder";
 
 describe("Which Type of Nature of Control Page", () => {
   const URL = getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL);
   const REDIRECT_URL = getUrl(TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL);
+  const REDIRECT_CONFIRM_URL = getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL);
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
   const cyTranslationText = { ...cyGeneralTranslationText, ...cyPersonWithSignificantControlTranslationText };
 
@@ -57,6 +58,8 @@ describe("Which Type of Nature of Control Page", () => {
         .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
         .build();
 
+      delete personWithSignificantControl.data?.principal_office_address;
+
       appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
 
       const res = await request(app).post(URL)
@@ -66,6 +69,23 @@ describe("Which Type of Nature of Control Page", () => {
 
       expect(res.status).toBe(302);
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
+
+    it("should redirect to the confirm principal office address page if the address is already saved", async () => {
+      const personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .isOtherRegistrablePerson()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+      const res = await request(app).post(URL)
+        .send({
+          pageType: RegistrationPageType.whichTypeOfNatureOfControlOtherRegistrablePerson
+        });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_CONFIRM_URL}`);
     });
   });
 });

--- a/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-relevant-legal-entity.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-relevant-legal-entity.test.ts
@@ -10,7 +10,7 @@ import { appDevDependencies } from "../../../../../config/dev-dependencies";
 import { WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL } from "../../../../controller/registration/url";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 
-import { TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../controller/addressLookUp/url/registration";
+import { CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL, TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../controller/addressLookUp/url/registration";
 
 import RegistrationPageType from "../../../../controller/registration/PageType";
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
@@ -19,6 +19,7 @@ import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSign
 describe("Which Type of Nature of Control Page", () => {
   const URL = getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL);
   const REDIRECT_URL = getUrl(TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL);
+  const REDIRECT_CONFIRM_URL = getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL);
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
   const cyTranslationText = { ...cyGeneralTranslationText, ...cyPersonWithSignificantControlTranslationText };
 
@@ -55,6 +56,8 @@ describe("Which Type of Nature of Control Page", () => {
         .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
         .build();
 
+      delete personWithSignificantControl.data?.principal_office_address;
+
       appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([
         personWithSignificantControl
       ]);
@@ -66,6 +69,23 @@ describe("Which Type of Nature of Control Page", () => {
 
       expect(res.status).toBe(302);
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
+
+    it("should redirect to the confirm principal office address page if the address is already saved", async () => {
+      const personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .isRelevantLegalEntity()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+      const res = await request(app).post(URL)
+        .send({
+          pageType: RegistrationPageType.whichTypeOfNatureOfControlRelevantLegalEntity
+        });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_CONFIRM_URL}`);
     });
   });
 });

--- a/src/presentation/test/integration/registration/personWithSignificantControl/will-partnership-have-psc.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/will-partnership-have-psc.test.ts
@@ -12,11 +12,13 @@ import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import {
   CHECK_YOUR_ANSWERS_URL,
   PERSON_WITH_SIGNIFICANT_CONTROL_CHOICE_URL,
+  REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL,
   WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL
 } from "../../../../controller/registration/url";
 
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import RegistrationPageType from "../../../../controller/registration/PageType";
+import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSignificantControlBuilder";
 
 describe("Will Limited Partnership Have PSC Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
@@ -26,6 +28,7 @@ describe("Will Limited Partnership Have PSC Page", () => {
   beforeEach(() => {
     setLocalesEnabled(true);
 
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([]);
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
     appDevDependencies.limitedPartnerGateway.feedErrors();
   });
@@ -58,12 +61,20 @@ describe("Will Limited Partnership Have PSC Page", () => {
 
     it.each([true, false, null])(
       "should preselect the has_person_with_significant_control value if it exists in the limited partnership data",
-      async (hasPscSelection: boolean) => {
-        const limitedPartnership = new LimitedPartnershipBuilder()
-          .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
-          .withHasPersonWithSignificantControl(hasPscSelection)
-          .build();
-        appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+      async (hasPscSelection: boolean | null) => {
+        if (hasPscSelection === null) {
+          const limitedPartnership = new LimitedPartnershipBuilder()
+            .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
+            .build();
+          appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+        } else {
+          const limitedPartnership = new LimitedPartnershipBuilder()
+            .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
+            .withHasPersonWithSignificantControl(hasPscSelection)
+            .build();
+          appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+        }
 
         const res = await request(app).get(URL);
 
@@ -99,6 +110,24 @@ describe("Will Limited Partnership Have PSC Page", () => {
         expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
       }
     );
+
+    it("should redirect to the summary page if has PSC selection is true and the user has already added a PSC", async () => {
+      const REDIRECT_URL = getUrl(REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL);
+      const personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .isRelevantLegalEntity()
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+      const res = await request(app).post(URL).send({
+        pageType: RegistrationPageType.willLimitedPartnershipHavePsc,
+        has_person_with_significant_control: "true"
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
 
     it("should show an error when no selection is made", async () => {
       const limitedPartnership = new LimitedPartnershipBuilder()

--- a/src/presentation/test/integration/registration/persons-with-significant-control.test.ts
+++ b/src/presentation/test/integration/registration/persons-with-significant-control.test.ts
@@ -10,13 +10,14 @@ import { TELL_US_ABOUT_PSC_URL, WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL } from "..
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { LimitedPartnership } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 
 describe("Tell Us About PSC Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
   const cyTranslationText = { ...cyGeneralTranslationText, ...cyPersonWithSignificantControlTranslationText };
   const URL = getUrl(TELL_US_ABOUT_PSC_URL);
   const REDIRECT_URL = getUrl(WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL);
-  let limitedPartnership;
+  let limitedPartnership: LimitedPartnership;
 
   beforeEach(() => {
     setLocalesEnabled(true);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1825


### Change description
Ensure we redirect to the review page from the will the partnership have PSCs page if one PSC exists
Ensure we redirect to the confirm principal office address page when an address is already saved (from the nature of control page)

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.