### PR TITLE
LP-1816: Display PSC details on Check Your Answers and validate lawful purpose

### DIFF
--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -16,6 +16,10 @@
             }
         },
 
+        "checkYourAnswers": {
+            "lawfulPurposeRequired": "WELSH - Confirm that the intended future activities are lawful"
+        },
+
         "dateOfUpdate": {
             "registeredOfficeAddress": "WELSH - Date the registered office address changed must be the same as or after limited partnership’s registration date",
             "principalPlaceOfBusinessAddress": "WELSH - Date the principal place of business changed must be the same as or after limited partnership’s registration date’",

--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -221,7 +221,8 @@
         "psc": {
             "title": "WELSH - People with significant control (PSCs)",
             "headingPscStatement": "WELSH - PSC statement",
-            "noPscStatement": "WELSH - There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership."
+            "noPscStatement": "WELSH - There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership.",
+            "changeRemoveOrAdd": "WELSH - Change, remove or add person with significant control (PSCs)"
         }
     },
 

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -16,6 +16,10 @@
             }
         },
 
+        "checkYourAnswers": {
+            "lawfulPurposeRequired": "Confirm that the intended future activities are lawful"
+        },
+
         "dateOfUpdate": {
             "registeredOfficeAddress": "Date the registered office address changed must be the same as or after limited partnership's registration date",
             "principalPlaceOfBusinessAddress": "Date the principal place of business changed must be the same as or after limited partnership's registration date",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -221,7 +221,8 @@
         "psc": {
             "title": "People with significant control (PSCs)",
             "headingPscStatement": "PSC statement",
-            "noPscStatement": "There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership."
+            "noPscStatement": "There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership.",
+            "changeRemoveOrAdd": "Change, remove or add person with significant control (PSCs)"
         }
     },
 

--- a/src/config/build-dependencies.ts
+++ b/src/config/build-dependencies.ts
@@ -136,6 +136,7 @@ export function buildDependencies(useInMemory = false): BuiltDependencies {
       limitedPartnershipService,
       generalPartnerService,
       limitedPartnerService,
+      personWithSignificantControlService,
       cacheService,
       paymentService
     );

--- a/src/domain/IPersonWithSignificantControlGateway.ts
+++ b/src/domain/IPersonWithSignificantControlGateway.ts
@@ -16,9 +16,9 @@ interface IPersonWithSignificantControlGateway {
   ): Promise<PersonWithSignificantControl>;
 
   getPersonsWithSignificantControl(
-      opt: { access_token: string; refresh_token: string },
-      transactionId: string
-    ): Promise<PersonWithSignificantControl[]>;
+    opt: Tokens,
+    transactionId: string
+  ): Promise<PersonWithSignificantControl[]>;
 
   sendPageData(
     opt: Tokens,

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -115,7 +115,7 @@ class LimitedPartnershipController extends PartnershipController {
       const { generalPartners } = await this.generalPartnerService.getGeneralPartners(tokens, transactionId);
       const { limitedPartners } = await this.limitedPartnerService.getLimitedPartners(tokens, transactionId);
       const { personsWithSignificantControl } =
-        await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, transactionId, false);
+        await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, transactionId);
 
       return { generalPartners, limitedPartners, personsWithSignificantControl };
     }

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -4,7 +4,8 @@ import {
   GeneralPartner,
   LimitedPartner,
   LimitedPartnership,
-  PartnershipType
+  PartnershipType,
+  PersonWithSignificantControl
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
@@ -20,6 +21,7 @@ import {
   JOURNEY_TYPE_PARAM
 } from "../../../config/constants";
 import CacheService from "../../../application/service/CacheService";
+import UIErrors from "../../../domain/entities/UIErrors";
 import { PageRouting } from "../PageRouting";
 import { getJourneyTypes } from "../../../utils";
 import {
@@ -35,6 +37,7 @@ import { PAYMENT_RESPONSE_URL } from "../global/url";
 
 import GeneralPartnerService from "../../../application/service/GeneralPartnerService";
 import LimitedPartnerService from "../../../application/service/LimitedPartnerService";
+import PersonWithSignificantControlService from "../../../application/service/PersonWithSignificantControlService";
 import PartnershipController from "../common/PartnershipController";
 
 class LimitedPartnershipController extends PartnershipController {
@@ -42,6 +45,7 @@ class LimitedPartnershipController extends PartnershipController {
     private readonly limitedPartnershipService: LimitedPartnershipService,
     private readonly generalPartnerService: GeneralPartnerService,
     private readonly limitedPartnerService: LimitedPartnerService,
+    private readonly personWithSignificantControlService: PersonWithSignificantControlService,
     private readonly cacheService: CacheService,
     private readonly paymentService: PaymentService
   ) {
@@ -69,7 +73,7 @@ class LimitedPartnershipController extends PartnershipController {
 
         this.conditionalPreviousUrl(ids, pageRouting, request, limitedPartnership);
 
-        const { generalPartners, limitedPartners } = await this.getPartners(
+        const { generalPartners, limitedPartners, personsWithSignificantControl } = await this.getCheckYourAnswersResources(
           pageRouting,
           tokens,
           ids.transactionId
@@ -79,7 +83,18 @@ class LimitedPartnershipController extends PartnershipController {
 
         response.render(
           super.templateName(pageRouting.currentUrl),
-          super.makeProps(pageRouting, { limitedPartnership, generalPartners, limitedPartners, cache, ids }, null)
+          super.makeProps(
+            pageRouting,
+            {
+              limitedPartnership,
+              generalPartners,
+              limitedPartners,
+              personsWithSignificantControl,
+              cache,
+              ids
+            },
+            null
+          )
         );
       } catch (error) {
         next(error);
@@ -87,18 +102,58 @@ class LimitedPartnershipController extends PartnershipController {
     };
   }
 
-  private async getPartners(
+  private async getCheckYourAnswersResources(
     pageRouting: PageRouting,
     tokens: Tokens,
     transactionId: string
-  ): Promise<{ generalPartners: GeneralPartner[]; limitedPartners: LimitedPartner[] }> {
+  ): Promise<{
+    generalPartners: GeneralPartner[];
+    limitedPartners: LimitedPartner[];
+    personsWithSignificantControl: PersonWithSignificantControl[];
+  }> {
     if (pageRouting.pageType === RegistrationPageType.checkYourAnswers) {
       const { generalPartners } = await this.generalPartnerService.getGeneralPartners(tokens, transactionId);
       const { limitedPartners } = await this.limitedPartnerService.getLimitedPartners(tokens, transactionId);
+      const { personsWithSignificantControl } =
+        await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, transactionId, false);
 
-      return { generalPartners, limitedPartners };
+      return { generalPartners, limitedPartners, personsWithSignificantControl };
     }
-    return { generalPartners: [], limitedPartners: [] };
+    return { generalPartners: [], limitedPartners: [], personsWithSignificantControl: [] };
+  }
+
+  private async renderCheckYourAnswersWithLawfulPurposeError(request: Request, response: Response) {
+    const { tokens, ids } = super.extract(request);
+    const pageRouting = super.getRouting(registrationsRouting, RegistrationPageType.checkYourAnswers, request);
+
+    const limitedPartnership = await this.limitedPartnershipService.getLimitedPartnership(
+      tokens,
+      ids.transactionId,
+      ids.submissionId
+    );
+
+    this.conditionalPreviousUrl(ids, pageRouting, request, limitedPartnership);
+
+    const { generalPartners, limitedPartners, personsWithSignificantControl } = await this.getCheckYourAnswersResources(
+      pageRouting,
+      tokens,
+      ids.transactionId
+    );
+
+    const uiErrors = new UIErrors();
+    uiErrors.setWebError(
+      "lawful_purpose_statement_checked",
+      response.locals.i18n.errorMessages.checkYourAnswers.lawfulPurposeRequired
+    );
+
+    response.render(
+      super.templateName(pageRouting.currentUrl),
+      super.makeProps(
+        pageRouting,
+        { limitedPartnership, generalPartners, limitedPartners, personsWithSignificantControl, ids },
+        uiErrors
+      )
+    );
   }
 
   private conditionalPreviousUrl(ids: Ids, pageRouting: PageRouting, request: Request, limitedPartnership?: LimitedPartnership) {
@@ -169,6 +224,10 @@ class LimitedPartnershipController extends PartnershipController {
       try {
         const { tokens, ids } = super.extract(request);
         const pageType = super.extractPageTypeOrThrowError(request, RegistrationPageType);
+
+        if (request.body.lawful_purpose_statement_checked !== "true") {
+          return await this.renderCheckYourAnswersWithLawfulPurposeError(request, response);
+        }
 
         await this.limitedPartnershipService.sendPageData(
           tokens,

--- a/src/presentation/controller/registration/routing/limitedPartnership.ts
+++ b/src/presentation/controller/registration/routing/limitedPartnership.ts
@@ -65,7 +65,8 @@ const registrationRoutingCheckYourAnswers = {
   pageType: RegistrationPageType.checkYourAnswers,
   data: {
     reviewGeneralPartnersType: RegistrationPageType.reviewGeneralPartners,
-    reviewLimitedPartnersType: RegistrationPageType.reviewLimitedPartners
+    reviewLimitedPartnersType: RegistrationPageType.reviewLimitedPartners,
+    reviewPersonsWithSignificantControlType: RegistrationPageType.reviewPersonsWithSignificantControl
   }
 };
 

--- a/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
+++ b/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
@@ -1,3 +1,5 @@
+import { PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+
 import TransactionPersonWithSignificantControl from "../../../domain/entities/TransactionPersonWithSignificantControl";
 
 export const personWithSignificantControlRelevantLegalEntity = {
@@ -7,14 +9,14 @@ export const personWithSignificantControlRelevantLegalEntity = {
   legal_entity_register_name: "US Register",
   legal_entity_registration_location: "United States",
   registered_company_number: "12345678",
-  type: "RELEVANT_LEGAL_ENTITY"
+  type: PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY
 };
 
 export const personWithSignificantControlOtherRegistrablePerson = {
   legal_entity_name: "My Company ltd - ORP",
   legal_form: "Limited Company",
   governing_law: "Act of law",
-  type: "OTHER_REGISTRABLE_PERSON"
+  type: PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON
 };
 
 class PersonWithSignificantControlBuilder {
@@ -59,8 +61,7 @@ class PersonWithSignificantControlBuilder {
   isRelevantLegalEntity() {
     this.data = {
       ...this.data,
-      ...personWithSignificantControlRelevantLegalEntity,
-      type: "RELEVANT_LEGAL_ENTITY"
+      ...personWithSignificantControlRelevantLegalEntity
     };
     return this;
   }
@@ -68,8 +69,7 @@ class PersonWithSignificantControlBuilder {
   isOtherRegistrablePerson() {
     this.data = {
       ...this.data,
-      ...personWithSignificantControlOtherRegistrablePerson,
-      type: "OTHER_REGISTRABLE_PERSON"
+      ...personWithSignificantControlOtherRegistrablePerson
     };
     return this;
   }

--- a/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
+++ b/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
@@ -59,7 +59,8 @@ class PersonWithSignificantControlBuilder {
   isRelevantLegalEntity() {
     this.data = {
       ...this.data,
-      ...personWithSignificantControlRelevantLegalEntity
+      ...personWithSignificantControlRelevantLegalEntity,
+      type: "RELEVANT_LEGAL_ENTITY"
     };
     return this;
   }
@@ -67,7 +68,8 @@ class PersonWithSignificantControlBuilder {
   isOtherRegistrablePerson() {
     this.data = {
       ...this.data,
-      ...personWithSignificantControlOtherRegistrablePerson
+      ...personWithSignificantControlOtherRegistrablePerson,
+      type: "OTHER_REGISTRABLE_PERSON"
     };
     return this;
   }

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -10,12 +10,16 @@ import {
 import { CHECK_YOUR_ANSWERS_URL } from "../../../controller/registration/url";
 import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
+import enErrorMessages from "../../../../../locales/en/errors.json";
+import cyErrorMessages from "../../../../../locales/cy/errors.json";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
+import PersonWithSignificantControlBuilder from "../../builder/PersonWithSignificantControlBuilder";
+import TransactionPersonWithSignificantControl from "../../../../domain/entities/TransactionPersonWithSignificantControl";
 import { formatDate } from "../../../../utils/date-format";
 import {
   EMAIL_TEMPLATE,
@@ -64,6 +68,8 @@ describe("Check Your Answers Page", () => {
       .withContributionSubtypes(["SHARES", "ANY_OTHER_ASSET"])
       .build();
     appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartnerPerson, limitedPartnerLegalEntity]);
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([]);
   });
 
   describe("GET Check Your Answers Page", () => {
@@ -434,29 +440,17 @@ describe("Check Your Answers Page", () => {
       }
     );
 
-    it.each([
-      ["true", true],
-      ["not set", undefined]
-    ])(
-      "should not display PSC statement section when has_person_with_significant_control is %s",
-      async (_description: string, hasPsc: boolean | undefined) => {
-        const builder = new LimitedPartnershipBuilder();
+    it("should not display PSC section when has_person_with_significant_control is not set", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
 
-        if (hasPsc !== undefined) {
-          builder.withHasPersonWithSignificantControl(hasPsc);
-        }
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
 
-        const limitedPartnership = builder.build();
+      const res = await request(app).get(URL);
 
-        appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
-
-        const res = await request(app).get(URL);
-
-        expect(res.status).toBe(200);
-        expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.title);
-        expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
-      }
-    );
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.title);
+      expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
+    });
 
     it.each([
       [PartnershipType.SLP, "will-the-partnership-have-any-people-with-significant-control"],
@@ -481,6 +475,107 @@ describe("Check Your Answers Page", () => {
     );
   });
 
+  describe("PSC details on CYA page", () => {
+    beforeEach(() => {
+      const limitedPartnership = new LimitedPartnershipBuilder().withHasPersonWithSignificantControl(true).build();
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([]);
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([]);
+    });
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])(
+      "should render the PSC section heading and change link in %s",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        setLocalesEnabled(true);
+
+        const rle = new PersonWithSignificantControlBuilder().isRelevantLegalEntity().build();
+        appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([rle]);
+
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(translationText.checkYourAnswersPage.psc.title);
+        expect(res.text).toContain(translationText.checkYourAnswersPage.psc.changeRemoveOrAdd);
+        expect(res.text).toContain("review-persons-with-significant-control");
+      }
+    );
+
+    const rleOnlyValues = () => {
+      const rleData = new PersonWithSignificantControlBuilder().isRelevantLegalEntity().build().data!;
+      return [rleData.legal_entity_register_name, rleData.registered_company_number];
+    };
+
+    it.each([
+      ["RELEVANT_LEGAL_ENTITY", () => new PersonWithSignificantControlBuilder().isRelevantLegalEntity().build(), true],
+      [
+        "OTHER_REGISTRABLE_PERSON",
+        () => new PersonWithSignificantControlBuilder().isOtherRegistrablePerson().build(),
+        false
+      ]
+    ])(
+      "should render the correct detail rows for %s",
+      async (
+        _type: string,
+        buildPsc: () => TransactionPersonWithSignificantControl,
+        expectRleOnlyRows: boolean
+      ) => {
+        const psc = buildPsc();
+        appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([psc]);
+
+        const res = await request(app).get(URL);
+        const { legal_entity_name, legal_form, governing_law } = psc.data!;
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(legal_entity_name);
+        expect(res.text).toContain(legal_form);
+        expect(res.text).toContain(governing_law);
+
+        rleOnlyValues().forEach((value) => {
+          if (expectRleOnlyRows) {
+            expect(res.text).toContain(value);
+          } else {
+            expect(res.text).not.toContain(value);
+          }
+        });
+      }
+    );
+
+    it("should render both an RLE and an ORP when both are present", async () => {
+      const rle = new PersonWithSignificantControlBuilder().withId("rle-id").isRelevantLegalEntity().build();
+      const orp = new PersonWithSignificantControlBuilder().withId("orp-id").isOtherRegistrablePerson().build();
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([rle, orp]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(rle.data!.legal_entity_name);
+      expect(res.text).toContain(orp.data!.legal_entity_name);
+    });
+
+    it("should render an ORP when legal_entity_registration_location is absent", async () => {
+      const orp = new PersonWithSignificantControlBuilder().withId("orp-id").isOtherRegistrablePerson().build();
+      delete orp.data!.legal_entity_registration_location;
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([orp]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(orp.data!.legal_entity_name);
+    });
+
+    it("should show the no PSC statement when user answered yes but no PSCs have been added", async () => {
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(enTranslationText.checkYourAnswersPage.psc.title);
+      expect(res.text).toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
+      expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.changeRemoveOrAdd);
+    });
+  });
+
   describe("POST Check Your Answers Page", () => {
     it("should send lawful purpose statement", async () => {
       const limitedPartnership = new LimitedPartnershipBuilder()
@@ -501,7 +596,8 @@ describe("Check Your Answers Page", () => {
 
     it("should navigate to next page", async () => {
       const res = await request(app).post(URL).send({
-        pageType: RegistrationPageType.checkYourAnswers
+        pageType: RegistrationPageType.checkYourAnswers,
+        lawful_purpose_statement_checked: "true"
       });
 
       expect(res.status).toBe(302);
@@ -512,11 +608,48 @@ describe("Check Your Answers Page", () => {
       // call transaction gateway and ovverride so there is no payment header
       appDevDependencies.paymentGateway.feedPaymentWithEmptyJourney();
       const res = await request(app).post(URL).send({
-        pageType: RegistrationPageType.checkYourAnswers
+        pageType: RegistrationPageType.checkYourAnswers,
+        lawful_purpose_statement_checked: "true"
       });
 
       expect(res.status).toBe(500);
       expect(res.text).not.toContain(`Redirecting to ${PAYMENT_LINK_JOURNEY}`);
+    });
+
+    it.each([
+      ["English", "en", enTranslationText, enErrorMessages],
+      ["Welsh", "cy", cyTranslationText, cyErrorMessages]
+    ])(
+      "should re-render the CYA page with an error summary in %s when lawful purpose statement is not ticked",
+      async (
+        _description: string,
+        lang: string,
+        translationText: Record<string, any>,
+        errorMessages: Record<string, any>
+      ) => {
+        setLocalesEnabled(true);
+
+        const res = await request(app)
+          .post(URL + `?lang=${lang}`)
+          .send({
+            pageType: RegistrationPageType.checkYourAnswers
+          });
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(errorMessages.errorMessages.checkYourAnswers.lawfulPurposeRequired);
+        expect(res.text).toContain('href="#lawful_purpose_statement_checked"');
+        expect(res.text).toContain(translationText.govUk.error.title);
+      }
+    );
+
+    it("should not send data when lawful purpose statement is not ticked", async () => {
+      await request(app).post(URL).send({
+        pageType: RegistrationPageType.checkYourAnswers
+      });
+
+      expect(
+        appDevDependencies.limitedPartnershipGateway.limitedPartnerships[0]?.data?.lawful_purpose_statement_checked
+      ).toBeUndefined();
     });
   });
 });

--- a/src/presentation/test/integration/registration/gateway/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/gateway/check-your-answers.test.ts
@@ -30,7 +30,8 @@ describe("Transaction Gateway Update tests for the 'Check Your Answers' page", (
 
   it("should update the transaction in order to close it", async () => {
     const res = await request(appRealDependencies).post(URL).send({
-      pageType: RegistrationPageType.checkYourAnswers
+      pageType: RegistrationPageType.checkYourAnswers,
+      lawful_purpose_statement_checked: "true"
     });
 
     expect(putTransaction).toHaveBeenCalled();
@@ -52,7 +53,8 @@ describe("Transaction Gateway Update tests for the 'Check Your Answers' page", (
     });
 
     const res = await request(appRealDependencies).post(URL).send({
-      pageType: RegistrationPageType.checkYourAnswers
+      pageType: RegistrationPageType.checkYourAnswers,
+      lawful_purpose_statement_checked: "true"
     });
 
     expect(res.status).toBe(500);
@@ -72,7 +74,8 @@ describe("Transaction Gateway Update tests for the 'Check Your Answers' page", (
     });
 
     const res = await request(appRealDependencies).post(URL).send({
-      pageType: RegistrationPageType.checkYourAnswers
+      pageType: RegistrationPageType.checkYourAnswers,
+      lawful_purpose_statement_checked: "true"
     });
 
     expect(res.status).toBe(500);
@@ -95,7 +98,8 @@ describe("Transaction Gateway Update tests for the 'Check Your Answers' page", (
     });
 
     const res = await request(appRealDependencies).post(URL).send({
-      pageType: RegistrationPageType.checkYourAnswers
+      pageType: RegistrationPageType.checkYourAnswers,
+      lawful_purpose_statement_checked: "true"
     });
 
     expect(res.status).toBe(500);

--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -22,6 +22,8 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       {% include "includes/proposed-name.njk" %}
 
+      {% include "includes/errors.njk" %}
+
       <h1 class="govuk-heading-l">{{ i18n.checkYourAnswersPage.title }}</h1>
 
       <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersPage.lpInfo }}</h2>
@@ -54,10 +56,25 @@
         {% endfor %}
       {% endif %}
 
-      {% if journeyTypes.isRegistration and props.data.limitedPartnership.data.has_person_with_significant_control === false %}
-        <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersPage.psc.title }}</h2>
+      {% if journeyTypes.isRegistration %}
+        {% set hasPsc = props.data.limitedPartnership.data.has_person_with_significant_control %}
+        {% set pscCount = props.data.personsWithSignificantControl.length or 0 %}
 
-        {% include "pages/checkYourAnswers/psc-statement.njk" %}
+        {% if hasPsc !== undefined %}
+          <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersPage.psc.title }}</h2>
+
+          {% if hasPsc === true and pscCount > 0 %}
+            <p class="govuk-body-m govuk-!-margin-bottom-6">
+              <a href="{{ props.currentUrl | replace(props.pageType, props.data.reviewPersonsWithSignificantControlType) }}" class="govuk-body-m govuk-link" data-event-id="change-link">{{ i18n.checkYourAnswersPage.psc.changeRemoveOrAdd }}</a>
+            </p>
+
+            {% for item in props.data.personsWithSignificantControl %}
+              {% include "pages/checkYourAnswers/person-with-significant-control.njk" %}
+            {% endfor %}
+          {% else %}
+            {% include "pages/checkYourAnswers/psc-statement.njk" %}
+          {% endif %}
+        {% endif %}
       {% endif %}
 
       <br>

--- a/src/views/pages/checkYourAnswers/lawful-purpose-statement.njk
+++ b/src/views/pages/checkYourAnswers/lawful-purpose-statement.njk
@@ -1,6 +1,6 @@
 {{ govukCheckboxes({
-  id: "lawfulPurposeStatementChecked", 
-  name: "lawful_purpose_statement_checked",            
+  name: "lawful_purpose_statement_checked",
+  errorMessage: props.errors.lawful_purpose_statement_checked if props.errors,
   fieldset: {
     legend: {
       text: i18n.checkYourAnswersPage.confirm,
@@ -11,10 +11,7 @@
   items: [
     {
       value: "true",
-      text: i18n.checkYourAnswersPage.futureLawful,
-      attributes: {
-        required: true
-      }
+      text: i18n.checkYourAnswersPage.futureLawful
     }
   ]
 }) }}

--- a/src/views/pages/checkYourAnswers/person-with-significant-control.njk
+++ b/src/views/pages/checkYourAnswers/person-with-significant-control.njk
@@ -1,0 +1,66 @@
+{% set isRle = item.data.type === "RELEVANT_LEGAL_ENTITY" %}
+{% if isRle and item.data.legal_entity_registration_location %}
+  {% set country = i18n.countries[macros.makeCamelCase(item.data.legal_entity_registration_location)] %}
+{% endif %}
+
+{{ govukSummaryList({
+  classes: "govuk-!-margin-bottom-7",
+  rows: [
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.name
+      },
+      value: {
+        text: item.data.legal_entity_name
+      }
+    },
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.legalForm
+      },
+      value: {
+        text: item.data.legal_form
+      }
+    },
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.governingLaw
+      },
+      value: {
+        text: item.data.governing_law
+      }
+    },
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.register
+      },
+      value: {
+        text: item.data.legal_entity_register_name
+      }
+    } if isRle,
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.countryRegisteredIn
+      },
+      value: {
+        text: country
+      }
+    } if isRle,
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.registrationNumber
+      },
+      value: {
+        text: item.data.registered_company_number
+      }
+    } if isRle,
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.legalEntity.principalOfficeAddress
+      },
+      value: {
+        text: macros.formatAddress(item.data.principal_office_address, true, i18n)
+      }
+    }
+  ]
+}) }}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1816

### Change description

Adds the PSC section to the Check Your Answers page and introduces GDS-compliant validation on the lawful purpose statement.

- `check-your-answers.njk`: renders the PSC section (heading, a "Change, remove or add" link, and per-PSC detail cards) when the user answered Yes and at least one PSC exists. Falls back to the "PSC statement" block otherwise. The change link points to the LP-1778 review page.
- New partial `pages/checkYourAnswers/person-with-significant-control.njk` renders each PSC's details (name, legal form, governing law, register, country, registration number, principal office). RLE-only rows are gated by the `type` discriminator. The `makeCamelCase` / country lookup is guarded against missing `legal_entity_registration_location`. See LP-1878 for an upstream API bug that can leave the field null.
- `postCheckYourAnswers` re-renders CYA with a GDS error summary and inline error when the user submits without ticking the lawful purpose statement. The summary `href` targets the checkbox input id.
- `getCheckYourAnswersResources` extended to pull PSCs alongside general/limited partners. Passes `checkCompletedField=false` since CYA doesn't own PSC-completeness validation (that's the review page's job).
- Localisation: English and Welsh strings added for the PSC section heading, change link, and the lawful purpose error message.
- Tests: new integration tests for the PSC rendering (RLE, ORP, mixed, empty, and the ORP-with-missing-location regression), error-summary rendering in both locales, and the "no data sent when checkbox unticked" behaviour.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.