### PR TITLE
LP-1816: npm audit fix for i18next-fs-backend, web-security-node, uuid

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,11 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.(ts|js)$': 'ts-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!uuid/)',
+  ],
   moduleDirectories: ['node_modules', 'src'],
   globalSetup: "./src/test/global.setup.ts",
   setupFilesAfterEnv: ['./src/test/setup-jest.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1188,16 +1189,16 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.4.15",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.15.tgz",
-      "integrity": "sha512-Y86Rz/Zd1FFUMwAkESKhTQXVjJDjwe8KXt3h2A27GUq8BQl+zq9c/A1f+DFkzAQjBKNRZ8Bkb90JGyecbv5e7Q==",
+      "version": "4.4.18",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.18.tgz",
+      "integrity": "sha512-ZkGwQT5bUcd3fjo5YkpDrGsqZzBwcQobP/SjNacO+Ry/u657oV5g5pD2UnKIXciilPVjV6JgfNwzRXJKAWNe2w==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "~5.2.10",
         "@companieshouse/structured-logging-node": "~2.0.7",
         "crypto": "^1.0.1",
         "express-async-handler": "^1.2.0",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -6340,9 +6341,9 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.1.tgz",
-      "integrity": "sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.4.tgz",
+      "integrity": "sha512-lzbUnowXYd5RFO8flpQhd9khYWNgrzwtxHw1kktJCiTRBaAEiLB2t9EPSXRj8qlC7WcEgFDIsmBUixyludcznw==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
@@ -9633,16 +9634,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@companieshouse/ch-node-utils": "^2.1.11",
         "@companieshouse/node-session-handler": "^5.2.8",
         "@companieshouse/structured-logging-node": "^2.0.4",
-        "@companieshouse/web-security-node": "^4.4.13",
+        "@companieshouse/web-security-node": "^4.4.18",
         "cookie-parser": "^1.4.7",
         "escape-html": "^1.0.3",
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@companieshouse/ch-node-utils": "^2.1.11",
     "@companieshouse/node-session-handler": "^5.2.8",
     "@companieshouse/structured-logging-node": "^2.0.4",
-    "@companieshouse/web-security-node": "^4.4.13",
+    "@companieshouse/web-security-node": "^4.4.18",
     "cookie-parser": "^1.4.7",
     "escape-html": "^1.0.3",
     "express": "^5.2.1",
@@ -65,6 +65,7 @@
     "ts-jest": "^29.4.6"
   },
   "overrides": {
-    "minimatch": "10.2.4"
+    "minimatch": "10.2.4",
+    "i18next-fs-backend": "^2.6.4"
   }
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1816

### Change description

Dependency check started failing on main after LP-1816 merged. `npm audit fix` resolves it within the existing semver ranges:

- `i18next-fs-backend` 2.6.1 → 2.6.4 (high, path traversal; transitive via ch-node-utils)
- `@companieshouse/web-security-node` 4.4.15 → 4.4.18 (bumps uuid from v9 to v14 as a side-effect)
- `follow-redirects` 1.15.11 → 1.16.0

Lockfile only, no `package.json` changes. Tests and lint green.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.