### PR TITLE
Ensure psc name displayed on natures of control page

### DIFF
--- a/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-other-registrable-person.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-other-registrable-person.test.ts
@@ -32,6 +32,12 @@ describe("Which Type of Nature of Control Page", () => {
       ["en", enTranslationText],
       ["cy", cyTranslationText]
     ])("should load the which type of nature of control page with %s text", async (lang: string, translationText: any) => {
+      const personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .isOtherRegistrablePerson()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
 
       const limitedPartnership = new LimitedPartnershipBuilder().build();
       appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
@@ -43,11 +49,10 @@ describe("Which Type of Nature of Control Page", () => {
       expect(res.text).toContain(
         `${translationText.personWithSignificantControl.whichTypeOfNatureOfControlPage.otherRegistrablePerson.title} - ${translationText.serviceRegistration} - GOV.UK`
       );
-      expect(res.text).toContain(
-        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} ${limitedPartnership?.data?.name_ending?.toUpperCase()}`
-      );
+
       testTranslations(res.text, translationText.personWithSignificantControl.whichTypeOfNatureOfControlPage.otherRegistrablePerson);
 
+      expect(res.text).toContain(personWithSignificantControl.data?.legal_entity_name?.toUpperCase());
     });
   });
 

--- a/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-relevant-legal-entity.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/which-type-of-nature-of-control-relevant-legal-entity.test.ts
@@ -31,7 +31,17 @@ describe("Which Type of Nature of Control Page", () => {
   });
 
   describe("Get Which Type of Nature of Control Page", () => {
-    it.each([["en", enTranslationText], ["cy", cyTranslationText]])("should load the which type of nature of control page with %s text", async (lang: string, translationText: any) => {
+    it.each([
+      ["en", enTranslationText],
+      ["cy", cyTranslationText]
+    ])("should load the which type of nature of control page with %s text", async (lang: string, translationText: any) => {
+      const personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .isRelevantLegalEntity()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
       const limitedPartnership = new LimitedPartnershipBuilder().build();
       appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
 
@@ -42,10 +52,10 @@ describe("Which Type of Nature of Control Page", () => {
       expect(res.text).toContain(
         `${translationText.personWithSignificantControl.whichTypeOfNatureOfControlPage.relevantLegalEntity.title} - ${translationText.serviceRegistration} - GOV.UK`
       );
-      expect(res.text).toContain(
-        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} ${limitedPartnership?.data?.name_ending?.toUpperCase()}`
-      );
+
       testTranslations(res.text, translationText.personWithSignificantControl.whichTypeOfNatureOfControlPage.relevantLegalEntity);
+
+      expect(res.text).toContain(personWithSignificantControl.data?.legal_entity_name?.toUpperCase());
     });
   });
 

--- a/src/views/pages/natureOfControl/which-type-of-nature-of-control.njk
+++ b/src/views/pages/natureOfControl/which-type-of-nature-of-control.njk
@@ -1,4 +1,4 @@
-{% include "includes/proposed-name.njk" %}
+{% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
 
 <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1829


### Change description
Ensure psc name displayed on all pages for psc's after the add psc pages (RLE + ORP)
Only necessary on natures of control pages (territory was already done in last PR, and the other address pages already include it.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.