### PR TITLE
Changes to back links on territory choice pages for ORP and RLE

### DIFF
--- a/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
@@ -1,8 +1,8 @@
 import AddressPageType from "../../PageType";
 import {
-  ADD_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_WITH_IDS_URL,
-  ADD_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_WITH_IDS_URL,
-  REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL
+  REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL,
+  WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL,
+  WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL
 } from "../../../registration/url";
 import * as url from "../../url/registration";
 
@@ -19,7 +19,7 @@ const personWithSignificantControlPrincipalOfficeAddressCacheKeys = {
 };
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress = {
-  previousUrl: ADD_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_WITH_IDS_URL,
+  previousUrl: WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL,
   currentUrl: url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL,
   nextUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL,
   pageType: AddressPageType.territoryChoicePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
@@ -82,7 +82,7 @@ const registrationAddressRoutingConfirmPersonWithSignificantControlRelevantLegal
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress =
   {
-    previousUrl: ADD_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_WITH_IDS_URL,
+    previousUrl: WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL,
     currentUrl:
       url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL,
     nextUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL,

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-principal-office-address.test.ts
@@ -23,7 +23,7 @@ describe("Choose principal office address of the person with significant control
   const URL_RELEVANT_LEGAL_ENTITY = getUrl(
     CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL
   );
-  const URL_OTHER_REGISTARBLE_PERSON = getUrl(
+  const URL_OTHER_REGISTRABLE_PERSON = getUrl(
     CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL
   );
 
@@ -49,8 +49,8 @@ describe("Choose principal office address of the person with significant control
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should load the choose principal office address of the person with significant control page with Welsh text for %s",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -72,8 +72,8 @@ describe("Choose principal office address of the person with significant control
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en"],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy"],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en"],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy"]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en"],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy"]
     ])("should populate the address list for %s", async (_description: string, URL: string, lang: string) => {
       const res = await request(app).get(URL + `?lang=${lang}`);
 
@@ -87,8 +87,8 @@ describe("Choose principal office address of the person with significant control
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should return error page when gateway getListOfValidPostcodeAddresses throws an error for %s",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -112,7 +112,7 @@ describe("Choose principal office address of the person with significant control
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.postcodePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         getUrl(CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-principal-office-address.test.ts
@@ -29,7 +29,7 @@ describe("Confirm PSC Principal Office Address Page", () => {
   const URL_RELEVANT_LEGAL_ENTITY = getUrl(
     CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL
   );
-  const URL_OTHER_REGISTARBLE_PERSON = getUrl(
+  const URL_OTHER_REGISTRABLE_PERSON = getUrl(
     CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL
   );
 
@@ -55,8 +55,8 @@ describe("Confirm PSC Principal Office Address Page", () => {
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should load the confirm PSC principal office address page with %s text",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -90,12 +90,12 @@ describe("Confirm PSC Principal Office Address Page", () => {
       ],
       [
         "ORP, overseas",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         getUrl(ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ],
       [
         "ORP unitedKingdom",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         getUrl(POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
     ])(
@@ -123,7 +123,7 @@ describe("Confirm PSC Principal Office Address Page", () => {
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])("should redirect to the next page for %s", async (_description: string, URL: string, pageType: string) => {
@@ -155,7 +155,7 @@ describe("Confirm PSC Principal Office Address Page", () => {
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])(
@@ -190,14 +190,14 @@ describe("Confirm PSC Principal Office Address Page", () => {
       [
         "ORP en",
         "en",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         enErrorMessages
       ],
       [
         "ORP cy",
         "cy",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         cyErrorMessages
       ]

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/enter-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/enter-psc-principal-office-address.test.ts
@@ -26,7 +26,7 @@ describe("Enter person with significant control's principal office manual addres
   const URL_RELEVANT_LEGAL_ENTITY = getUrl(
     ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL
   );
-  const URL_OTHER_REGISTARBLE_PERSON = getUrl(
+  const URL_OTHER_REGISTRABLE_PERSON = getUrl(
     ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL
   );
 
@@ -46,8 +46,8 @@ describe("Enter person with significant control's principal office manual addres
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should load enter person with significant controls principal office address page with English text",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -83,7 +83,7 @@ describe("Enter person with significant control's principal office manual addres
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
@@ -115,7 +115,7 @@ describe("Enter person with significant control's principal office manual addres
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])(
@@ -149,7 +149,7 @@ describe("Enter person with significant control's principal office manual addres
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
@@ -184,7 +184,7 @@ describe("Enter person with significant control's principal office manual addres
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])(
@@ -241,7 +241,7 @@ describe("Enter person with significant control's principal office manual addres
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])(

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-principal-office-address.test.ts
@@ -34,7 +34,7 @@ describe("Postcode person with significant control's principal office address pa
   const URL_RELEVANT_LEGAL_ENTITY = getUrl(
     POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL
   );
-  const URL_OTHER_REGISTARBLE_PERSON = getUrl(
+  const URL_OTHER_REGISTRABLE_PERSON = getUrl(
     POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL
   );
 
@@ -52,8 +52,8 @@ describe("Postcode person with significant control's principal office address pa
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should load the principal office address page with English text",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -95,7 +95,7 @@ describe("Postcode person with significant control's principal office address pa
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.postcodePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         getUrl(CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
@@ -137,7 +137,7 @@ describe("Postcode person with significant control's principal office address pa
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.postcodePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
         getUrl(CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
@@ -163,7 +163,7 @@ describe("Postcode person with significant control's principal office address pa
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         AddressPageType.postcodePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
       ]
     ])(

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
@@ -33,7 +33,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
   const URL_RELEVANT_LEGAL_ENTITY = getUrl(
     TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_RELEVANT_LEGAL_ENTITY_PRINCIPAL_OFFICE_ADDRESS_URL
   );
-  const URL_OTHER_REGISTARBLE_PERSON = getUrl(
+  const URL_OTHER_REGISTRABLE_PERSON = getUrl(
     TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL
   );
 
@@ -50,8 +50,8 @@ describe("PSC Principal Office Address Territory Choice", () => {
     it.each([
       ["RLE English", URL_RELEVANT_LEGAL_ENTITY, "en", enTranslationText],
       ["RLE Welsh", URL_RELEVANT_LEGAL_ENTITY, "cy", cyTranslationText],
-      ["ORP English", URL_OTHER_REGISTARBLE_PERSON, "en", enTranslationText],
-      ["ORP Welsh", URL_OTHER_REGISTARBLE_PERSON, "cy", cyTranslationText]
+      ["ORP English", URL_OTHER_REGISTRABLE_PERSON, "en", enTranslationText],
+      ["ORP Welsh", URL_OTHER_REGISTRABLE_PERSON, "cy", cyTranslationText]
     ])(
       "should load the PSC principal office address territory choice page with %s text",
       async (_description: string, URL: string, lang: string, translationText: Record<string, any>) => {
@@ -79,7 +79,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
 
     it.each([
       ["RLE", URL_RELEVANT_LEGAL_ENTITY, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL)],
-      ["ORP", URL_OTHER_REGISTARBLE_PERSON, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL)]
+      ["ORP", URL_OTHER_REGISTRABLE_PERSON, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL)]
     ])(
       "should contain the correct back link for PSC type",
       async (_description: string, URL: string, expectedBackLink: string) => {
@@ -103,7 +103,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         getUrl(POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
     ])(
@@ -136,7 +136,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
       ],
       [
         "ORP",
-        URL_OTHER_REGISTARBLE_PERSON,
+        URL_OTHER_REGISTRABLE_PERSON,
         getUrl(ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_OTHER_REGISTRABLE_PERSON_PRINCIPAL_OFFICE_ADDRESS_URL)
       ]
     ])(
@@ -163,7 +163,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
 
     it.each([
       ["RLE", URL_RELEVANT_LEGAL_ENTITY],
-      ["ORP", URL_OTHER_REGISTARBLE_PERSON]
+      ["ORP", URL_OTHER_REGISTRABLE_PERSON]
     ])("should show an error message when no selection is made for territory choice", async (_description: string, URL: string) => {
       const personWithSignificantControl = buildPSC(_description);
       appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
@@ -81,7 +81,7 @@ describe("PSC Principal Office Address Territory Choice", () => {
       ["RLE", URL_RELEVANT_LEGAL_ENTITY, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL)],
       ["ORP", URL_OTHER_REGISTRABLE_PERSON, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL)]
     ])(
-      "should contain the correct back link for PSC type",
+      "should have a back link to the correct natures of control page for %s",
       async (_description: string, URL: string, expectedBackLink: string) => {
         const personWithSignificantControl = buildPSC(_description);
         appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-principal-office-address.test.ts
@@ -25,6 +25,8 @@ import AddressPageType from "../../../../../controller/addressLookUp/PageType";
 import LimitedPartnershipBuilder from "../../../../builder/LimitedPartnershipBuilder";
 import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
 
+import { WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL, WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL } from "presentation/controller/registration/url";
+
 describe("PSC Principal Office Address Territory Choice", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
   const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorsTranslationText };
@@ -72,6 +74,22 @@ describe("PSC Principal Office Address Territory Choice", () => {
         testTranslations(res.text, translationText.address.territories);
 
         expect(res.text).toContain(personWithSignificantControl.data?.legal_entity_name?.toUpperCase());
+      }
+    );
+
+    it.each([
+      ["RLE", URL_RELEVANT_LEGAL_ENTITY, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL)],
+      ["ORP", URL_OTHER_REGISTARBLE_PERSON, getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL)]
+    ])(
+      "should contain the correct back link for PSC type",
+      async (_description: string, URL: string, expectedBackLink: string) => {
+        const personWithSignificantControl = buildPSC(_description);
+        appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+        const res = await request(app).get(URL);
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(`href="${expectedBackLink}"`);
       }
     );
   });

--- a/src/views/uk-or-overseas-person-with-significant-control-other-registrable-person-principal-office-address.njk
+++ b/src/views/uk-or-overseas-person-with-significant-control-other-registrable-person-principal-office-address.njk
@@ -1,12 +1,5 @@
 {% extends "layout.njk" %}
 
-{# Back Link #}
-{% if props.data.personWithSignificantControl.data.legal_entity_name %}
-  {% set hrefValue = props.currentUrl | replace(props.pageType, "add-person-with-significant-control-other-registrable-person") %}
-{% else %}
-  {% set hrefValue = props.previousUrl %}
-{% endif %}
-
 {% set pageTitle = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.title %}
 {% set titleHint = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.titleHint %}
 {% set publicRegisterInformationLine1 = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.publicRegisterInformationLine1 %}

--- a/src/views/uk-or-overseas-person-with-significant-control-relevant-legal-entity-principal-office-address.njk
+++ b/src/views/uk-or-overseas-person-with-significant-control-relevant-legal-entity-principal-office-address.njk
@@ -1,12 +1,5 @@
 {% extends "layout.njk" %}
 
-{# Back Link #}
-{% if props.data.personWithSignificantControl.data.legal_entity_name %}
-  {% set hrefValue = props.currentUrl | replace(props.pageType, "add-person-with-significant-control-relevant-legal-entity") %}
-{% else %}
-  {% set hrefValue = props.previousUrl %}
-{% endif %}
-
 {% set pageTitle = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.title %}
 {% set titleHint = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.titleHint %}
 {% set publicRegisterInformationLine1 = i18n.address.territoryChoice.personWithSignificantControlPrincipalOfficeAddress.publicRegisterInformationLine1 %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1828


### Change description
Changed previousUrl for ORP and RLE Territory choice routing to which natures of control URL
Removed unused logic for back links on territory choice templates 
Added test to check the back link is correct for both ORP and RLE pages 

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.