### PR TITLE
LP-1228: Saved filing validation and hide PSC for non-Scottish LPs

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -301,7 +301,8 @@
         "no": {
           "text": "WELSH - No, start a new filing",
           "hint": "WELSH - This will not delete any saved filings"
-        }
+        },
+        "errorMessage": "WELSH - Select whether to continue with a saved filing"
     },
 
     "dateOfUpdate" : {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -301,7 +301,8 @@
         "no": {
           "text": "No, start a new filing",
           "hint": "This will not delete any saved filings"
-        }
+        },
+        "errorMessage": "Select whether to continue with a saved filing"
     },
 
     "dateOfUpdate" : {

--- a/src/presentation/controller/common/PartnershipController.ts
+++ b/src/presentation/controller/common/PartnershipController.ts
@@ -2,12 +2,30 @@ import { NextFunction, Request, Response } from "express";
 
 import AbstractController from "../AbstractController";
 import { YOUR_FILINGS_URL } from "../../../config/constants";
+import UIErrors from "../../../domain/entities/UIErrors";
 
 class PartnershipController extends AbstractController {
   continueSavedFiling(pageType, routing) {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
-        if (request.body["continue_saved_filing"] === "YES") {
+        const selection = request.body["continue_saved_filing"];
+
+        if (selection !== "YES" && selection !== "NO") {
+          const type = this.extractPageTypeOrThrowError(request, pageType);
+          const pageRouting = this.getRouting(routing, type, request);
+
+          const uiErrors = new UIErrors().setWebError(
+            "continue_saved_filing",
+            response.locals.i18n.continueSavedFilingPage.errorMessage
+          );
+
+          return response.render(
+            this.templateName(pageRouting.currentUrl),
+            this.makeProps(pageRouting, null, uiErrors)
+          );
+        }
+
+        if (selection === "YES") {
           return response.redirect(YOUR_FILINGS_URL);
         }
 

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -424,6 +424,7 @@ describe("Check Your Answers Page", () => {
         setLocalesEnabled(true);
 
         const limitedPartnership = new LimitedPartnershipBuilder()
+          .withPartnershipType(PartnershipType.SLP)
           .withHasPersonWithSignificantControl(false)
           .build();
 
@@ -441,7 +442,7 @@ describe("Check Your Answers Page", () => {
     );
 
     it("should not display PSC section when has_person_with_significant_control is not set", async () => {
-      const limitedPartnership = new LimitedPartnershipBuilder().build();
+      const limitedPartnership = new LimitedPartnershipBuilder().withPartnershipType(PartnershipType.SLP).build();
 
       appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
 
@@ -451,6 +452,28 @@ describe("Check Your Answers Page", () => {
       expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.title);
       expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
     });
+
+    it.each([
+      [PartnershipType.LP],
+      [PartnershipType.PFLP]
+    ])(
+      "should not display PSC section for non-Scottish partnership type %s even when has_person_with_significant_control is set",
+      async (partnershipType: PartnershipType) => {
+        const limitedPartnership = new LimitedPartnershipBuilder()
+          .withPartnershipType(partnershipType)
+          .withHasPersonWithSignificantControl(false)
+          .build();
+
+        appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+        const res = await request(app).get(URL);
+
+        expect(res.status).toBe(200);
+        expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.title);
+        expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
+        expect(res.text).not.toContain("change-psc-statement-button");
+      }
+    );
 
     it.each([
       [PartnershipType.SLP, "will-the-partnership-have-any-people-with-significant-control"],
@@ -477,7 +500,10 @@ describe("Check Your Answers Page", () => {
 
   describe("PSC details on CYA page", () => {
     beforeEach(() => {
-      const limitedPartnership = new LimitedPartnershipBuilder().withHasPersonWithSignificantControl(true).build();
+      const limitedPartnership = new LimitedPartnershipBuilder()
+        .withPartnershipType(PartnershipType.SLP)
+        .withHasPersonWithSignificantControl(true)
+        .build();
       appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
       appDevDependencies.generalPartnerGateway.feedGeneralPartners([]);
       appDevDependencies.limitedPartnerGateway.feedLimitedPartners([]);

--- a/src/presentation/test/integration/registration/continue-saved-filing.test.ts
+++ b/src/presentation/test/integration/registration/continue-saved-filing.test.ts
@@ -19,9 +19,10 @@ describe("Continue Saved Filing Page", () => {
     const res = await request(app).get(CONTINUE_SAVED_FILING_URL + "?lang=en");
 
     expect(res.status).toBe(200);
-    testTranslations(res.text, enTranslationText.continueSavedFilingPage);
+    testTranslations(res.text, enTranslationText.continueSavedFilingPage, ["errorMessage"]);
     expect(res.text).toContain(enTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_REGISTRATION);
+    expect(res.text).not.toContain(enTranslationText.continueSavedFilingPage.errorMessage);
   });
 
   it("should load the page with Welsh text", async () => {
@@ -30,9 +31,10 @@ describe("Continue Saved Filing Page", () => {
     const res = await request(app).get(CONTINUE_SAVED_FILING_URL + "?lang=cy");
 
     expect(res.status).toBe(200);
-    testTranslations(res.text, cyTranslationText.continueSavedFilingPage);
+    testTranslations(res.text, cyTranslationText.continueSavedFilingPage, ["errorMessage"]);
     expect(res.text).toContain(cyTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_REGISTRATION);
+    expect(res.text).not.toContain(cyTranslationText.continueSavedFilingPage.errorMessage);
   });
 
   it("should redirect to partnership-type page", async () => {
@@ -54,4 +56,25 @@ describe("Continue Saved Filing Page", () => {
     expect(res.status).toBe(302);
     expect(res.text).toContain(`Redirecting to ${YOUR_FILINGS_URL}`);
   });
+
+  it.each([
+    ["English", "en", enTranslationText],
+    ["Welsh", "cy", cyTranslationText]
+  ])(
+    "should re-render the page with an error summary in %s when no option is selected",
+    async (_description: string, lang: string, translationText: Record<string, any>) => {
+      setLocalesEnabled(true);
+
+      const res = await request(app)
+        .post(CONTINUE_SAVED_FILING_URL + `?lang=${lang}`)
+        .send({
+          pageType: RegistrationPageType.continueSavedFiling
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(translationText.continueSavedFilingPage.errorMessage);
+      expect(res.text).toContain('href="#continue_saved_filing"');
+      expect(res.text).toContain(translationText.govUk.error.title);
+    }
+  );
 });

--- a/src/presentation/test/integration/transition/continue-saved-filing.test.ts
+++ b/src/presentation/test/integration/transition/continue-saved-filing.test.ts
@@ -25,9 +25,10 @@ describe("Continue Saved Filing Page", () => {
     const res = await request(app).get(CONTINUE_SAVED_FILING_URL + "?lang=en");
 
     expect(res.status).toBe(200);
-    testTranslations(res.text, enTranslationText.continueSavedFilingPage);
+    testTranslations(res.text, enTranslationText.continueSavedFilingPage, ["errorMessage"]);
     expect(res.text).toContain(enTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_TRANSITION);
+    expect(res.text).not.toContain(enTranslationText.continueSavedFilingPage.errorMessage);
   });
 
   it("should load the page with Welsh text", async () => {
@@ -36,9 +37,10 @@ describe("Continue Saved Filing Page", () => {
     const res = await request(app).get(CONTINUE_SAVED_FILING_URL + "?lang=cy");
 
     expect(res.status).toBe(200);
-    testTranslations(res.text, cyTranslationText.continueSavedFilingPage);
+    testTranslations(res.text, cyTranslationText.continueSavedFilingPage, ["errorMessage"]);
     expect(res.text).toContain(cyTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_TRANSITION);
+    expect(res.text).not.toContain(cyTranslationText.continueSavedFilingPage.errorMessage);
   });
 
   it("should redirect to company number page", async () => {
@@ -60,4 +62,25 @@ describe("Continue Saved Filing Page", () => {
     expect(res.status).toBe(302);
     expect(res.text).toContain(`Redirecting to ${YOUR_FILINGS_URL}`);
   });
+
+  it.each([
+    ["English", "en", enTranslationText],
+    ["Welsh", "cy", cyTranslationText]
+  ])(
+    "should re-render the page with an error summary in %s when no option is selected",
+    async (_description: string, lang: string, translationText: Record<string, any>) => {
+      setLocalesEnabled(true);
+
+      const res = await request(app)
+        .post(CONTINUE_SAVED_FILING_URL + `?lang=${lang}`)
+        .send({
+          pageType: TransitionPageType.continueSavedFiling
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(translationText.continueSavedFilingPage.errorMessage);
+      expect(res.text).toContain('href="#continue_saved_filing"');
+      expect(res.text).toContain(translationText.govUk.error.title);
+    }
+  );
 });

--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -58,10 +58,12 @@
       {% endif %}
 
       {% if journeyTypes.isRegistration %}
+        {% set partnershipType = props.data.limitedPartnership.data.partnership_type %}
+        {% set isScottishPartnership = partnershipType === "SLP" or partnershipType === "SPFLP" %}
         {% set hasPsc = props.data.limitedPartnership.data.has_person_with_significant_control %}
         {% set pscCount = props.data.personsWithSignificantControl.length or 0 %}
 
-        {% if hasPsc !== undefined %}
+        {% if isScottishPartnership and hasPsc !== undefined %}
           <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersPage.psc.title }}</h2>
 
           {% if hasPsc === true and pscCount > 0 %}

--- a/src/views/continue-saved-filing.njk
+++ b/src/views/continue-saved-filing.njk
@@ -32,9 +32,6 @@
               text: i18n.continueSavedFilingPage.yes.text,
               hint: {
                 text: i18n.continueSavedFilingPage.yes.hint
-              },
-              attributes: {
-                "required": true
               }
             },
             {
@@ -42,9 +39,6 @@
               text: i18n.continueSavedFilingPage.no.text,
               hint: {
                 text: i18n.continueSavedFilingPage.no.hint
-              },
-              attributes: {
-                "required": true
               }
             }
           ],

--- a/src/views/continue-saved-filing.njk
+++ b/src/views/continue-saved-filing.njk
@@ -6,10 +6,11 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
 
       <form class="form" method="post">
         <input type="hidden" name="pageType" value={{ props.pageType }}>
-      
+
         {% include "includes/csrf_token.njk" %}
 
         {{ govukRadios({
@@ -46,7 +47,10 @@
                 "required": true
               }
             }
-          ]
+          ],
+          errorMessage: {
+            text: i18n.continueSavedFilingPage.errorMessage
+          } if props.errors
         }) }}
 
         {{ govukButton({


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1228


### Change description

lp-1228: Add GDS validation on the "Do you want to continue with a saved filing?" page. When no radio is selected the controller now re-renders the page with an error summary and inline error ("Select whether to continue with a saved filing"), for both the registration and transition journeys.

Also added fix for PSC rendering bug on CYA page.

lp-1904: Hide the PSC section on the registration check-your-answers page when the limited partnership is non-Scottish. Previously the section was gated only by whether has_person_with_significant_control was defined on the LP, which meant LP/PFLP registrations could render it with an active Change link into a journey that does not apply, and submitting triggered the API validation error against data.hasPersonWithSignificantControl. Now also gate by partnership_type === SLP/SPFLP, matching the existing controller routing in LimitedPartnershipController.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.