### PR TITLE
add limitedPartnership validator class and validate name page, term page, type page using validator

### DIFF
--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -68,12 +68,19 @@
             "lawfulPurposeRequired": "WELSH - Confirm that the intended future activities are lawful"
         },
 
-        "term": {
-            "termRequired": "WELSH - Select the term of the partnership"
-        },
-
-        "partnershipType": {
-            "typeRequired": "WELSH - Select the type of partnership you are registering"
+        "limitedPartnership": {
+            "partnershipType": {
+                "typeRequired": "WELSH - Select the type of partnership you are registering"
+            },
+            "name": {
+                "nameInvalid": "WELSH - Limited partnership name must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
+                "nameLength": "WELSH - Partnership name (including name ending) must be 160 characters or less",
+                "nameRequired": "WELSH - Enter the partnership name",
+                "nameEndingRequired": "WELSH - Select the name ending to go on the public record"
+            },
+            "term": {
+                "termRequired": "WELSH - Select the term of the partnership"
+            }
         },
 
         "personWithSignificantControl": {

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -67,12 +67,19 @@
             "lawfulPurposeRequired": "Confirm that the intended future activities are lawful"
         },
 
-        "term": {
-            "termRequired": "Select the term of the partnership"
-        },
-
-        "partnershipType": {
-            "typeRequired": "Select the type of partnership you are registering"
+        "limitedPartnership": {
+            "partnershipType": {
+                "typeRequired": "Select the type of partnership you are registering"
+            },
+            "name": {
+                "nameInvalid": "Limited partnership name must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
+                "nameLength": "Partnership name (including name ending) must be 160 characters or less",
+                "nameRequired": "Enter the partnership name",
+                "nameEndingRequired": "Select the name ending to go on the public record"
+            },
+            "term": {
+                "termRequired": "Select the term of the partnership"
+            }
         },
 
         "personWithSignificantControl": {

--- a/src/application/service/LimitedPartnershipService.ts
+++ b/src/application/service/LimitedPartnershipService.ts
@@ -11,13 +11,33 @@ import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { JourneyTypes } from "../../domain/entities/journey";
 import PageType from "../../presentation/controller/PageType";
+import LimitedPartnershipValidator from "../../domain/validator/LimitedPartnership";
 
 class LimitedPartnershipService {
+  i18n: any;
+
   constructor(
     private readonly limitedPartnershipGateway: ILimitedPartnershipGateway,
     private readonly transactionGateway: ITransactionGateway,
-    private readonly incorporationGateway: IIncorporationGateway
+    private readonly incorporationGateway: IIncorporationGateway,
+    private readonly limitedPartnershipValidator: LimitedPartnershipValidator
   ) {}
+
+  setI18n(i18n: any) {
+    this.i18n = i18n;
+  }
+
+  runNameValidation(data: Record<string, any>): UIErrors {
+    return this.limitedPartnershipValidator.set(data, this.i18n).runNameValidation();
+  }
+
+  runTermValidation(data: Record<string, any>): UIErrors {
+    return this.limitedPartnershipValidator.set(data, this.i18n).runTermValidation();
+  }
+
+  runPartnershipTypeValidation(data: Record<string, any>): UIErrors {
+    return this.limitedPartnershipValidator.set(data, this.i18n).runPartnershipTypeValidation();
+  }
 
   async createLimitedPartnership(
     opt: { access_token: string; refresh_token: string },

--- a/src/config/build-dependencies.ts
+++ b/src/config/build-dependencies.ts
@@ -23,6 +23,7 @@ import PersonWithSignificantControlInMemoryGateway from "../infrastructure/gatew
 
 import AddressValidator from "../domain/validator/Address";
 import PersonWithSignificantControlValidator from "../domain/validator/PersonWithSignificantControl";
+import LimitedPartnershipValidator from "../domain/validator/LimitedPartnership";
 
 import CacheService from "../application/service/CacheService";
 import AddressLookUpService from "../application/service/AddressService";
@@ -110,12 +111,14 @@ export function buildDependencies(useInMemory = false): BuiltDependencies {
   // Dommain
   const addressValidator = new AddressValidator();
   const personWithSignificantControlValidator = new PersonWithSignificantControlValidator();
+  const limitedPartnershipValidator = new LimitedPartnershipValidator();
 
   // Services
   const limitedPartnershipService: LimitedPartnershipService = new LimitedPartnershipService(
     limitedPartnershipGateway,
     transactionGateway,
-    incorporationGateway
+    incorporationGateway,
+    limitedPartnershipValidator
   );
   const addressLookUpService: AddressLookUpService = new AddressLookUpService(addressLookUpGateway, addressValidator);
   const cacheService = new CacheService(cacheRepository);

--- a/src/domain/validator/LimitedPartnership.ts
+++ b/src/domain/validator/LimitedPartnership.ts
@@ -32,7 +32,6 @@ class LimitedPartnershipValidator {
   }
 
   private partnershipTypeEmpty(uiErrors: UIErrors): UIErrors {
-    console.log(this.partnership_type);
     if (!this.partnership_type) {
       uiErrors.setWebError("partnership_type", this.errorMessages?.partnershipType?.typeRequired);
     }

--- a/src/domain/validator/LimitedPartnership.ts
+++ b/src/domain/validator/LimitedPartnership.ts
@@ -40,7 +40,7 @@ class LimitedPartnershipValidator {
   }
 
   private isValidPartnershipType(uiErrors: UIErrors): UIErrors {
-    if (this.partnership_type && !Object.values(PartnershipType).includes(this.partnership_type as PartnershipType)) {
+    if (this.partnership_type && !Object.values(PartnershipType).includes(this.partnership_type)) {
       uiErrors.setWebError("partnership_type", this.errorMessages?.partnershipType?.typeRequired);
     }
     return uiErrors;
@@ -77,7 +77,7 @@ class LimitedPartnershipValidator {
 
   private checkPartnershipNameLength(uiErrors: UIErrors): UIErrors {
     const partnershipNameMaxLength = 160;
-    const partnershipName = this.partnership_name?.trim() || "";
+    const partnershipName = this.partnership_name?.trim() ?? "";
     const partnershipNameWithEnding = `${partnershipName} ${this.name_ending}`;
 
     if (partnershipName && partnershipNameWithEnding.length > partnershipNameMaxLength) {
@@ -97,7 +97,7 @@ class LimitedPartnershipValidator {
   }
 
   private isValidTerm(uiErrors: UIErrors): UIErrors {
-    if (this.term && !Object.values(Term).includes(this.term as Term)) {
+    if (this.term && !Object.values(Term).includes(this.term)) {
       uiErrors.setWebError("term", this.errorMessages?.term?.termRequired);
     }
     return uiErrors;

--- a/src/domain/validator/LimitedPartnership.ts
+++ b/src/domain/validator/LimitedPartnership.ts
@@ -1,0 +1,114 @@
+import { NameEndingType, PartnershipType, Term } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+import { VALID_CHARACTERS_REGEX } from "../../config/constants";
+import UIErrors from "../entities/UIErrors";
+
+class LimitedPartnershipValidator {
+  private partnership_type?: PartnershipType;
+  private partnership_name?: string;
+  private name_ending?: NameEndingType;
+  private term?: Term;
+
+  private errorMessages: Record<string, any> = {};
+
+  set(data: Record<string, any>, i18n: any): this {
+    this.partnership_type = data.partnership_type;
+    this.partnership_name = data.partnership_name;
+    this.name_ending = data.name_ending;
+    this.term = data.term;
+
+    this.errorMessages = i18n?.errorMessages?.limitedPartnership || {};
+
+    return this;
+  }
+
+  // Partnership Type
+  public runPartnershipTypeValidation(): UIErrors {
+    const uiErrors = new UIErrors();
+
+    this.partnershipTypeEmpty(uiErrors);
+    this.isValidPartnershipType(uiErrors);
+
+    return uiErrors;
+  }
+
+  private partnershipTypeEmpty(uiErrors: UIErrors): UIErrors {
+    console.log(this.partnership_type);
+    if (!this.partnership_type) {
+      uiErrors.setWebError("partnership_type", this.errorMessages?.partnershipType?.typeRequired);
+    }
+    return uiErrors;
+  }
+
+  private isValidPartnershipType(uiErrors: UIErrors): UIErrors {
+    if (this.partnership_type && !Object.values(PartnershipType).includes(this.partnership_type as PartnershipType)) {
+      uiErrors.setWebError("partnership_type", this.errorMessages?.partnershipType?.typeRequired);
+    }
+    return uiErrors;
+  }
+
+  // Partnership Name
+  public runNameValidation(): UIErrors {
+    const uiErrors = new UIErrors();
+
+    this.isEmpty(uiErrors);
+    this.isValidCharacters(uiErrors);
+    this.checkPartnershipNameLength(uiErrors);
+    return uiErrors;
+  }
+
+  private isEmpty(uiErrors: UIErrors): UIErrors {
+    if (!this.partnership_name?.trim()) {
+      uiErrors.setWebError("partnership_name", this.errorMessages?.name?.nameRequired);
+    }
+    if (!this.name_ending){
+      uiErrors.setWebError("name_ending", this.errorMessages?.name?.nameEndingRequired);
+    }
+    return uiErrors;
+  }
+
+  private isValidCharacters(uiErrors: UIErrors): UIErrors {
+    const conditionNotMet = (value: string) => !VALID_CHARACTERS_REGEX.test(value);
+
+    if (this.partnership_name && conditionNotMet(this.partnership_name)) {
+      uiErrors.setWebError("partnership_name", this.errorMessages?.name?.nameInvalid);
+    }
+    return uiErrors;
+  }
+
+  private checkPartnershipNameLength(uiErrors: UIErrors): UIErrors {
+    const partnershipNameMaxLength = 160;
+    const partnershipName = this.partnership_name?.trim() || "";
+    const partnershipNameWithEnding = `${partnershipName} ${this.name_ending}`;
+
+    if (partnershipName && partnershipNameWithEnding.length > partnershipNameMaxLength) {
+      uiErrors.setWebError("partnership_name", this.errorMessages?.name?.nameLength);
+    }
+    return uiErrors;
+  }
+
+  // Term
+  public runTermValidation(): UIErrors {
+    const uiErrors = new UIErrors();
+
+    this.termEmpty(uiErrors);
+    this.isValidTerm(uiErrors);
+
+    return uiErrors;
+  }
+
+  private isValidTerm(uiErrors: UIErrors): UIErrors {
+    if (this.term && !Object.values(Term).includes(this.term as Term)) {
+      uiErrors.setWebError("term", this.errorMessages?.term?.termRequired);
+    }
+    return uiErrors;
+  }
+
+  private termEmpty(uiErrors: UIErrors): UIErrors {
+    if (!this.term) {
+      uiErrors.setWebError("term", this.errorMessages?.term?.termRequired);
+    }
+    return uiErrors;
+  }
+}
+
+export default LimitedPartnershipValidator;

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -301,6 +301,7 @@ class LimitedPartnershipController extends PartnershipController {
   redirectPartnershipTypeWithIds() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
+        this.limitedPartnerService.setI18n(response.locals.i18n);
         const { tokens, ids } = super.extract(request);
 
         const selectedPartnershipType = escape(request.body.partnership_type);

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -5,8 +5,7 @@ import {
   LimitedPartner,
   LimitedPartnership,
   PartnershipType,
-  PersonWithSignificantControl,
-  Term
+  PersonWithSignificantControl
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
@@ -60,6 +59,7 @@ class LimitedPartnershipController extends PartnershipController {
       try {
         this.generalPartnerService.setI18n(response.locals.i18n);
         this.limitedPartnerService.setI18n(response.locals.i18n);
+        this.limitedPartnershipService.setI18n(response.locals.i18n);
 
         const { tokens, pageType, ids } = super.extract(request);
         const pageRouting = super.getRouting(registrationsRouting, pageType, request);
@@ -192,10 +192,25 @@ class LimitedPartnershipController extends PartnershipController {
   createTransactionAndFirstSubmission() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
+        this.limitedPartnershipService.setI18n(response.locals.i18n);
         const { tokens } = super.extract(request);
         const pageType = super.extractPageTypeOrThrowError(request, RegistrationPageType);
         const pageRouting = super.getRouting(registrationsRouting, pageType, request);
         const journeyTypes = getJourneyTypes(pageRouting.currentUrl);
+
+        if (RegistrationPageType.partnershipName === pageType) {
+          const errors: UIErrors | undefined = this.limitedPartnershipService.runNameValidation(request.body);
+
+          if (errors.hasErrors()) {
+            const cache = this.cacheService.getDataFromCache(request.signedCookies);
+
+            response.render(
+              super.templateName(pageRouting.currentUrl),
+              super.makeProps(pageRouting, { limitedPartnership: { data: request.body }, cache }, errors)
+            );
+            return;
+          }
+        }
 
         const result = await this.limitedPartnershipService.createTransactionAndFirstSubmission(
           tokens,
@@ -288,7 +303,7 @@ class LimitedPartnershipController extends PartnershipController {
       try {
         const { tokens, ids } = super.extract(request);
 
-        const selectedPartnershipType = escape(request.body.parameter);
+        const selectedPartnershipType = escape(request.body.partnership_type);
 
         const limitedPartnership: LimitedPartnership = await this.limitedPartnershipService.getLimitedPartnership(
           tokens,
@@ -315,22 +330,21 @@ class LimitedPartnershipController extends PartnershipController {
         const pageRouting = super.getRouting(registrationsRouting, type, request);
 
         const pageType = escape(request.body.pageType);
-        const parameter = escape(request.body.parameter);
+        const partnershipType = escape(request.body.partnership_type);
 
-        if (type === RegistrationPageType.partnershipType && !this.isValidPartnershipType(parameter)) {
-          const uiErrors = new UIErrors().setWebError(
-            "parameter",
-            response.locals.i18n.errorMessages.partnershipType.typeRequired
-          );
+        if (type === RegistrationPageType.partnershipType) {
+          const uiErrors = this.limitedPartnershipService.runPartnershipTypeValidation(request.body);
 
-          return response.render(
-            super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, {}, uiErrors)
-          );
+          if (uiErrors.hasErrors()) {
+            return response.render(
+              super.templateName(pageRouting.currentUrl),
+              super.makeProps(pageRouting, {}, uiErrors)
+            );
+          }
         }
 
         const cache = this.cacheService.addDataToCache(request.signedCookies, {
-          [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${pageType}`]: parameter
+          [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${pageType}`]: partnershipType
         });
         response.cookie(APPLICATION_CACHE_KEY, cache, cookieOptions);
 
@@ -341,33 +355,20 @@ class LimitedPartnershipController extends PartnershipController {
     };
   }
 
-  private isValidPartnershipType(value: string): boolean {
-    return Object.values(PartnershipType).includes(value as PartnershipType);
-  }
-
   sendPageData() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
+        this.limitedPartnershipService.setI18n(response.locals.i18n);
         const { tokens, ids } = super.extract(request);
         const pageType = super.extractPageTypeOrThrowError(request, RegistrationPageType);
         const pageRouting = super.getRouting(registrationsRouting, pageType, request);
 
-        if (pageType === RegistrationPageType.term && !this.isValidTerm(request.body.term)) {
-          const limitedPartnership = await this.limitedPartnershipService.getLimitedPartnership(
-            tokens,
-            ids.transactionId,
-            ids.submissionId
-          );
+        if (pageType === RegistrationPageType.term) {
+          const errors: UIErrors = this.limitedPartnershipService.runTermValidation(request.body);
 
-          const uiErrors = new UIErrors().setWebError(
-            "term",
-            response.locals.i18n.errorMessages.term.termRequired
-          );
-
-          return response.render(
-            super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, { limitedPartnership }, uiErrors)
-          );
+          if (errors.hasErrors()) {
+            return this.handleTermMissingOrInvalid(request, response, errors);
+          }
         }
 
         const result = await this.limitedPartnershipService.sendPageData(
@@ -413,8 +414,20 @@ class LimitedPartnershipController extends PartnershipController {
     };
   }
 
-  private isValidTerm(value: string): boolean {
-    return Object.values(Term).includes(value as Term);
+  private async handleTermMissingOrInvalid(request: Request, response: Response, uiErrors: UIErrors) {
+    const { tokens, ids } = super.extract(request);
+    const pageRouting = super.getRouting(registrationsRouting, RegistrationPageType.term, request);
+
+    const limitedPartnership = await this.limitedPartnershipService.getLimitedPartnership(
+      tokens,
+      ids.transactionId,
+      ids.submissionId
+    );
+
+    return response.render(
+      super.templateName(pageRouting.currentUrl),
+      super.makeProps(pageRouting, { limitedPartnership }, uiErrors)
+    );
   }
 
   private async conditionalNextUrl(tokens: Tokens, ids: Ids, pageRouting: PageRouting, request: Request) {
@@ -434,6 +447,7 @@ class LimitedPartnershipController extends PartnershipController {
   getPageRoutingTermSic() {
     return async (request: Request, response: Response, next: NextFunction) => {
       try {
+        this.limitedPartnershipService.setI18n(response.locals.i18n);
         const { tokens, pageType, ids } = super.extract(request);
         const pageRouting = super.getRouting(registrationsRouting, pageType, request);
 

--- a/src/presentation/test/integration/registration/gateway/email.test.ts
+++ b/src/presentation/test/integration/registration/gateway/email.test.ts
@@ -152,7 +152,9 @@ describe("Gateway Update - Refresh Token", () => {
         });
 
         const res = await request(appRealDependencies).post(NAME_URL).send({
-          pageType: RegistrationPageType.partnershipName
+          pageType: RegistrationPageType.partnershipName,
+          partnership_name: "partnership name",
+          name_ending: NameEndingType.LIMITED_PARTNERSHIP
         });
 
         expect(res.status).toBe(200);

--- a/src/presentation/test/integration/registration/gateway/name.test.ts
+++ b/src/presentation/test/integration/registration/gateway/name.test.ts
@@ -89,7 +89,9 @@ describe("Gateway Transaction - Incorporation - Partnership", () => {
         });
 
         const res = await request(appRealDependencies).post(NAME_URL).send({
-          pageType: RegistrationPageType.partnershipName
+          pageType: RegistrationPageType.partnershipName,
+          partnership_name: "partnership name",
+          name_ending: NameEndingType.LIMITED_PARTNERSHIP
         });
 
         expect(res.status).toBe(200);
@@ -112,7 +114,9 @@ describe("Gateway Transaction - Incorporation - Partnership", () => {
       });
 
       const res = await request(appRealDependencies).post(NAME_URL).send({
-        pageType: RegistrationPageType.partnershipName
+        pageType: RegistrationPageType.partnershipName,
+        partnership_name: "partnership name",
+        name_ending: NameEndingType.LIMITED_PARTNERSHIP
       });
 
       expect(res.status).toBe(500);

--- a/src/presentation/test/integration/registration/name.test.ts
+++ b/src/presentation/test/integration/registration/name.test.ts
@@ -2,8 +2,10 @@ import request from "supertest";
 import { Request, Response } from "express";
 import { NameEndingType, PartnershipType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
-import enTranslationText from "../../../../../locales/en/translations.json";
-import cyTranslationText from "../../../../../locales/cy/translations.json";
+import enGeneralTranslationText from "../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../locales/cy/translations.json";
+import enErrorsTranslationText from "../../../../../locales/en/errors.json";
+import cyErrorsTranslationText from "../../../../../locales/cy/errors.json";
 import app from "../app";
 import { EMAIL_URL, NAME_URL, NAME_WITH_IDS_URL } from "../../../controller/registration/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
@@ -18,10 +20,12 @@ import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations, toEscapedHtml } from "../../utils";
 
 describe("Name Page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enErrorsTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyErrorsTranslationText };
   const REDIRECT_URL = getUrl(EMAIL_URL);
 
   beforeEach(() => {
-    setLocalesEnabled(false);
+    setLocalesEnabled(true);
 
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
     appDevDependencies.limitedPartnershipGateway.feedErrors();
@@ -29,39 +33,24 @@ describe("Name Page", () => {
   });
 
   describe("Get Name Page", () => {
-    it("should load the name page with Welsh text", async () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])("should load the name page with %s text", async (_description: string, lang: string, translationText: Record<string, any>) => {
       setLocalesEnabled(true);
 
       appDevDependencies.cacheRepository.feedCache({
         [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.LP
       });
 
-      const res = await request(app).get(NAME_URL + "?lang=cy");
+      const res = await request(app).get(NAME_URL + `?lang=${lang}`);
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(
-        `${cyTranslationText.namePage.title} - ${cyTranslationText.serviceRegistration} - GOV.UK`
+        `${translationText.namePage.title} - ${translationText.serviceRegistration} - GOV.UK`
       );
-      testTranslations(res.text, cyTranslationText.namePage, ["privateFund", "scottish"]);
-      expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
-    });
-
-    it("should load the name page with English text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.LP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=en");
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(
-        `${enTranslationText.namePage.title} - ${enTranslationText.serviceRegistration} - GOV.UK`
-      );
-      testTranslations(res.text, enTranslationText.namePage, ["privateFund", "scottish"]);
-      expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
-      expect(res.text).not.toContain("WELSH -");
+      testTranslations(res.text, translationText.namePage, ["privateFund", "scottish"]);
+      expect(res.text).toContain(translationText.buttons.saveAndContinue);
     });
 
     it("should load the name page with data from api", async () => {
@@ -81,108 +70,34 @@ describe("Name Page", () => {
       expect(res.text).toContain(limitedPartnership?.data?.name_ending);
     });
 
-    it("should load the private name page with Welsh text", async () => {
-      setLocalesEnabled(true);
+    it.each([
+      ["English", "en", enTranslationText.namePage.privateFund, PartnershipType.PFLP, ],
+      ["Welsh", "cy", cyTranslationText.namePage.privateFund, PartnershipType.PFLP, ],
+      ["English", "en", enTranslationText.namePage.scottish, PartnershipType.SLP, ],
+      ["Welsh", "cy", cyTranslationText.namePage.scottish, PartnershipType.SLP, ],
+      ["English", "en", enTranslationText.namePage.privateFund.scottish, PartnershipType.SPFLP, ],
+      ["Welsh", "cy", cyTranslationText.namePage.privateFund.scottish, PartnershipType.SPFLP, ]
+    ])("should load the name page with %s text for %s partnership type", async (
+      _description: string,
+      lang: string,
+      partnershipTypeTranslation: Record<string, any>,
+      partnershipType: PartnershipType
+    ) => {
+      const translationText = lang === "en" ? enTranslationText : cyTranslationText;
 
       appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.PFLP
+        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: partnershipType
       });
 
-      const res = await request(app).get(NAME_URL + "?lang=cy");
+      const res = await request(app).get(NAME_URL + `?lang=${lang}`);
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(
-        `${cyTranslationText.namePage.privateFund.title} - ${cyTranslationText.serviceRegistration} - GOV.UK`
+        `${partnershipTypeTranslation.title} - ${translationText.serviceRegistration} - GOV.UK`
       );
-      testTranslations(res.text, cyTranslationText.namePage.privateFund, ["scottish", "nameEnding"]);
-      expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
-    });
-
-    it("should load the private name page with English text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.PFLP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=en");
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(
-        `${enTranslationText.namePage.privateFund.title} - ${enTranslationText.serviceRegistration} - GOV.UK`
-      );
-      testTranslations(res.text, enTranslationText.namePage.privateFund, ["scottish", "nameEnding"]);
-      expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
-      expect(res.text).not.toContain("WELSH -");
-    });
-
-    it("should load the Scottish limited partnership name page with Welsh text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.SLP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=cy");
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(
-        `${cyTranslationText.namePage.scottish.title} - ${cyTranslationText.serviceRegistration} - GOV.UK`
-      );
-      testTranslations(res.text, cyTranslationText.namePage.scottish);
-      expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
-    });
-
-    it("should load the Scottish limited partnership name page with English text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.SLP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=en");
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(
-        `${enTranslationText.namePage.scottish.title} - ${enTranslationText.serviceRegistration} - GOV.UK`
-      );
-      testTranslations(res.text, enTranslationText.namePage.scottish);
-      expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
-      expect(res.text).not.toContain("WELSH -");
-    });
-
-    it("should load the private name Scotland page with Welsh text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.SPFLP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=cy");
-
-      expect(res.status).toBe(200);
-      testTranslations(res.text, cyTranslationText.namePage.privateFund.scottish);
-      expect(res.text).toContain(toEscapedHtml(cyTranslationText.namePage.whatIsNameHint));
-      expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
-    });
-
-    it("should load the private name Scotland page with English text", async () => {
-      setLocalesEnabled(true);
-
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.SPFLP
-      });
-
-      const res = await request(app).get(NAME_URL + "?lang=en");
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(
-        `${enTranslationText.namePage.privateFund.scottish.title} - ${enTranslationText.serviceRegistration} - GOV.UK`
-      );
-      testTranslations(res.text, enTranslationText.namePage.privateFund.scottish);
-      expect(res.text).toContain(toEscapedHtml(enTranslationText.namePage.whatIsNameHint));
-      expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
-      expect(res.text).not.toContain("WELSH -");
+      testTranslations(res.text, partnershipTypeTranslation, ["scottish", "nameEnding"]);
+      expect(res.text).toContain(translationText.buttons.saveAndContinue);
+      expect(res.text).toContain(toEscapedHtml(translationText.namePage.whatIsNameHint));
     });
 
     it("should load the name page with ids in back link url when name page has ids in url", async () => {
@@ -193,17 +108,6 @@ describe("Name Page", () => {
       expect(res.status).toBe(200);
       const regex = new RegExp(`${REGISTRATION_BASE_URL}/transaction/.*?/submission/.*?/partnership-type`);
       expect(res.text).toMatch(regex);
-    });
-
-    it("should load the name page with status 200", async () => {
-      appDevDependencies.cacheRepository.feedCache({
-        [`${APPLICATION_CACHE_KEY_PREFIX_REGISTRATION}${RegistrationPageType.partnershipType}`]: PartnershipType.LP
-      });
-
-      const res = await request(app).get(NAME_URL);
-
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(toEscapedHtml(enTranslationText.namePage.whatIsName));
     });
   });
 
@@ -257,13 +161,57 @@ describe("Name Page", () => {
       expect(appDevDependencies.limitedPartnershipGateway.limitedPartnerships.length).toEqual(1);
     });
 
-    it("should return validation errors", async () => {
-      const res = await request(app).post(NAME_URL).send({
-        pageType: RegistrationPageType.partnershipName
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])("should return validation errors if partnership name + name ending length exceeds limit in %s", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app).post(NAME_URL + `?lang=${lang}`).send({
+        pageType: RegistrationPageType.partnershipName,
+        partnership_name: "a".repeat(157),
+        name_ending: NameEndingType.LIMITED_PARTNERSHIP
       });
 
       expect(res.status).toBe(200);
-      expect(res.text).toContain("partnership_name must be less than 160");
+      expect(res.text).toContain(translationText.errorMessages.limitedPartnership.name.nameLength);
+    });
+
+    it("should not return validation errors when partnership name + name ending length is exactly at the limit", async () => {
+      const res = await request(app).post(NAME_URL).send({
+        pageType: RegistrationPageType.partnershipName,
+        partnership_name: "a".repeat(157),
+        name_ending: NameEndingType.LP
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])("should return validation errors if partnership name contains invalid characters in %s", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app).post(NAME_URL + `?lang=${lang}`).send({
+        pageType: RegistrationPageType.partnershipName,
+        partnership_name: "partnership_name",
+        name_ending: NameEndingType.LIMITED_PARTNERSHIP
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(translationText.errorMessages.limitedPartnership.name.nameInvalid);
+    });
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])("should return validation errors if partnership name is empty or name ending is missing in %s", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app).post(NAME_URL + `?lang=${lang}`).send({
+        pageType: RegistrationPageType.partnershipName,
+        partnership_name: ""
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(translationText.errorMessages.limitedPartnership.name.nameRequired);
+      expect(res.text).toContain(translationText.errorMessages.limitedPartnership.name.nameEndingRequired);
     });
 
     it("should return a status 500 if page type doesn't exist - sq", async () => {

--- a/src/presentation/test/integration/registration/term.test.ts
+++ b/src/presentation/test/integration/registration/term.test.ts
@@ -2,8 +2,8 @@ import request from "supertest";
 import { PartnershipType, Term } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 
 import app from "../app";
-import enTranslationText from "../../../../../locales/en/translations.json";
-import cyTranslationText from "../../../../../locales/cy/translations.json";
+import enGeneralTranslationText from "../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../locales/cy/translations.json";
 import enErrorMessages from "../../../../../locales/en/errors.json";
 import cyErrorMessages from "../../../../../locales/cy/errors.json";
 
@@ -15,6 +15,9 @@ import RegistrationPageType from "../../../controller/registration/PageType";
 import { ApiErrors } from "../../../../domain/entities/UIErrors";
 
 describe("Email Page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enErrorMessages };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyErrorMessages };
+
   const URL = getUrl(TERM_URL);
   const REDIRECT_URL = getUrl(SIC_URL);
 
@@ -134,15 +137,14 @@ describe("Email Page", () => {
       });
 
       it.each([
-        ["English", "en", enTranslationText, enErrorMessages],
-        ["Welsh", "cy", cyTranslationText, cyErrorMessages]
+        ["English", "en", enTranslationText],
+        ["Welsh", "cy", cyTranslationText]
       ])(
         "should re-render the page with an error summary in %s when no term is selected",
         async (
           _description: string,
           lang: string,
-          translationText: Record<string, any>,
-          errorMessages: Record<string, any>
+          translationText
         ) => {
           const limitedPartnership = new LimitedPartnershipBuilder()
             .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
@@ -158,7 +160,7 @@ describe("Email Page", () => {
             });
 
           expect(res.status).toBe(200);
-          expect(res.text).toContain(errorMessages.errorMessages.term.termRequired);
+          expect(res.text).toContain(translationText.errorMessages.limitedPartnership.term.termRequired);
           expect(res.text).toContain('href="#term"');
           expect(res.text).toContain(translationText.govUk.error.title);
         }
@@ -178,7 +180,7 @@ describe("Email Page", () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.text).toContain(enErrorMessages.errorMessages.term.termRequired);
+        expect(res.text).toContain(enErrorMessages.errorMessages.limitedPartnership.term.termRequired);
         expect(res.text).toContain('href="#term"');
       });
     });

--- a/src/presentation/test/integration/registration/which-type.test.ts
+++ b/src/presentation/test/integration/registration/which-type.test.ts
@@ -41,7 +41,7 @@ describe("Which type Page", () => {
     testTranslations(res.text, enTranslationText.types);
     expect(res.text).toContain(enTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_REGISTRATION);
-    expect(res.text).not.toContain(enErrorMessages.errorMessages.partnershipType.typeRequired);
+    expect(res.text).not.toContain(enErrorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
   });
 
   it("should load the partnership-type page with Welsh text", async () => {
@@ -53,7 +53,7 @@ describe("Which type Page", () => {
     testTranslations(res.text, cyTranslationText.partnershipTypePage);
     expect(res.text).toContain(cyTranslationText.buttons.continue);
     expect(res.text).toContain(SERVICE_NAME_REGISTRATION);
-    expect(res.text).not.toContain(cyErrorMessages.errorMessages.partnershipType.typeRequired);
+    expect(res.text).not.toContain(cyErrorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
   });
 
   it("should redirect to name page and cache contains the type selected", async () => {
@@ -61,7 +61,7 @@ describe("Which type Page", () => {
 
     const res = await request(app).post(PARTNERSHIP_TYPE_URL).send({
       pageType: RegistrationPageType.partnershipType,
-      parameter: selectedType
+      partnership_type: selectedType
     });
 
     expect(res.status).toBe(302);
@@ -83,7 +83,7 @@ describe("Which type Page", () => {
 
     const res = await request(app).post(PARTNERSHIP_TYPE_URL).send({
       pageType: RegistrationPageType.partnershipType,
-      parameter: selectedType
+      partnership_type: selectedType
     });
 
     expect(res.status).toBe(302);
@@ -106,7 +106,7 @@ describe("Which type Page", () => {
 
     const res = await request(app).post(getUrl(PARTNERSHIP_TYPE_WITH_IDS_URL)).send({
       pageType: RegistrationPageType.partnershipType,
-      parameter: PartnershipType.PFLP
+      partnership_type: PartnershipType.PFLP
     });
 
     expect(res.status).toBe(302);
@@ -123,7 +123,7 @@ describe("Which type Page", () => {
 
     const res = await request(app).post(getUrl(PARTNERSHIP_TYPE_WITH_IDS_URL)).send({
       pageType: RegistrationPageType.partnershipType,
-      parameter: PartnershipType.LP
+      partnership_type: PartnershipType.LP
     });
 
     expect(res.status).toBe(302);
@@ -150,8 +150,8 @@ describe("Which type Page", () => {
         });
 
       expect(res.status).toBe(200);
-      expect(res.text).toContain(errorMessages.errorMessages.partnershipType.typeRequired);
-      expect(res.text).toContain('href="#parameter"');
+      expect(res.text).toContain(errorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
+      expect(res.text).toContain('href="#partnership_type"');
       expect(res.text).toContain(translationText.govUk.error.title);
       expect(appDevDependencies.cacheRepository.cache).toBeNull();
     }
@@ -164,12 +164,12 @@ describe("Which type Page", () => {
       .post(PARTNERSHIP_TYPE_URL + "?lang=en")
       .send({
         pageType: RegistrationPageType.partnershipType,
-        parameter: "INVALID"
+        partnership_type: "INVALID"
       });
 
     expect(res.status).toBe(200);
-    expect(res.text).toContain(enErrorMessages.errorMessages.partnershipType.typeRequired);
-    expect(res.text).toContain('href="#parameter"');
+    expect(res.text).toContain(enErrorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
+    expect(res.text).toContain('href="#partnership_type"');
     expect(appDevDependencies.cacheRepository.cache).toBeNull();
   });
 });

--- a/src/presentation/test/unit/domain/limited-partnership-validation.spec.ts
+++ b/src/presentation/test/unit/domain/limited-partnership-validation.spec.ts
@@ -50,8 +50,11 @@ describe("Limited Partnership Validation", () => {
   });
 
   describe("Name validation", () => {
-    it("should not return an error if name is valid", () => {
-      const limitedPartnership = new LimitedPartnership().set({ partnership_name: "Valid Name", name_ending: NameEndingType.LP }, enTranslationText);
+    it.each([
+      ["Valid Name", NameEndingType.LP],
+      ["A".repeat(157) + " ", NameEndingType.LP]
+    ])("should not return an error if name is valid", (name, nameEnding) => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: name, name_ending: nameEnding }, enTranslationText);
       const errors = limitedPartnership.runNameValidation();
 
       expect(errors.hasErrors()).toBe(false);
@@ -102,8 +105,7 @@ describe("Limited Partnership Validation", () => {
     });
 
     it("should return an error if name with ending is too long", () => {
-      const longName = "A".repeat(158);
-      const limitedPartnership = new LimitedPartnership().set({ partnership_name: longName, name_ending: NameEndingType.LP }, enTranslationText);
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: "A".repeat(158), name_ending: NameEndingType.LP }, enTranslationText);
       const errors = limitedPartnership.runNameValidation();
 
       expect(errors.hasErrors()).toBe(true);

--- a/src/presentation/test/unit/domain/limited-partnership-validation.spec.ts
+++ b/src/presentation/test/unit/domain/limited-partnership-validation.spec.ts
@@ -1,0 +1,169 @@
+import { NameEndingType, PartnershipType, Term } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+import LimitedPartnership from "../../../../domain/validator/LimitedPartnership";
+import enTranslationText from "../../../../../locales/en/errors.json";
+
+describe("Limited Partnership Validation", () => {
+  describe("Partnership Type validation", () => {
+    it("should not return an error if partnership type is valid", () => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_type: PartnershipType.LP }, enTranslationText);
+      const errors = limitedPartnership.runPartnershipTypeValidation();
+
+      expect(errors.hasErrors()).toBe(false);
+      expect(errors.getErrors()).toEqual({ errorList: [] });
+    });
+
+    it("should return an error if partnership type is empty", () => {
+      const limitedPartnership = new LimitedPartnership().set({}, enTranslationText);
+      const errors = limitedPartnership.runPartnershipTypeValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        partnership_type: {
+          text: enTranslationText.errorMessages.limitedPartnership.partnershipType.typeRequired
+        },
+        errorList: [
+          {
+            href: "#partnership_type",
+            text: enTranslationText.errorMessages.limitedPartnership.partnershipType.typeRequired
+          }
+        ]
+      });
+    });
+
+    it("should return an error if partnership type is invalid", () => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_type: "invalid" }, enTranslationText);
+      const errors = limitedPartnership.runPartnershipTypeValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors ()).toEqual({
+        partnership_type: {
+          text: enTranslationText.errorMessages.limitedPartnership.partnershipType.typeRequired
+        },
+        errorList: [
+          {
+            href: "#partnership_type",
+            text: enTranslationText.errorMessages.limitedPartnership.partnershipType.typeRequired
+          }
+        ]
+      });
+    });
+  });
+
+  describe("Name validation", () => {
+    it("should not return an error if name is valid", () => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: "Valid Name", name_ending: NameEndingType.LP }, enTranslationText);
+      const errors = limitedPartnership.runNameValidation();
+
+      expect(errors.hasErrors()).toBe(false);
+      expect(errors.getErrors()).toEqual({ errorList: [] });
+    });
+
+    it("should return an error if name or name ending is empty", () => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: " ", name_ending: "" }, enTranslationText);
+      const errors = limitedPartnership.runNameValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        partnership_name: {
+          text: enTranslationText.errorMessages.limitedPartnership.name.nameRequired
+        },
+        name_ending: {
+          text: enTranslationText.errorMessages.limitedPartnership.name.nameEndingRequired
+        },
+        errorList: [
+          {
+            href: "#partnership_name",
+            text: enTranslationText.errorMessages.limitedPartnership.name.nameRequired
+          },
+          {
+            href: "#name_ending",
+            text: enTranslationText.errorMessages.limitedPartnership.name.nameEndingRequired
+          }
+        ]
+      });
+    });
+
+    it("should return an error if name contains invalid characters", () => {
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: "Invalid_Name", name_ending: NameEndingType.LP }, enTranslationText);
+      const errors = limitedPartnership.runNameValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        partnership_name: {
+          text: enTranslationText.errorMessages.limitedPartnership.name.nameInvalid
+        },
+        errorList: [
+          {
+            href: "#partnership_name",
+            text: enTranslationText.errorMessages.limitedPartnership.name.nameInvalid
+          }
+        ]
+      });
+    });
+
+    it("should return an error if name with ending is too long", () => {
+      const longName = "A".repeat(158);
+      const limitedPartnership = new LimitedPartnership().set({ partnership_name: longName, name_ending: NameEndingType.LP }, enTranslationText);
+      const errors = limitedPartnership.runNameValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        partnership_name: {
+          text: enTranslationText.errorMessages.limitedPartnership.name.nameLength
+        },
+        errorList: [
+          {
+            href: "#partnership_name",
+            text: enTranslationText.errorMessages.limitedPartnership.name.nameLength
+          }
+        ]
+      });
+    });
+  });
+
+  describe("Term validation", () => {
+    it("should not return an error if term is valid", () => {
+      const limitedPartnership = new LimitedPartnership().set({ term: Term.BY_AGREEMENT }, enTranslationText);
+      const errors = limitedPartnership.runTermValidation();
+
+      expect(errors.hasErrors()).toBe(false);
+      expect(errors.getErrors()).toEqual({ errorList: [] });
+    });
+
+    it("should return an error if term is invalid", () => {
+      const limitedPartnership = new LimitedPartnership().set({ term: "invalid" }, enTranslationText);
+      const errors = limitedPartnership.runTermValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        term: {
+          text: enTranslationText.errorMessages.limitedPartnership.term.termRequired
+        },
+        errorList: [
+          {
+            href: "#term",
+            text: enTranslationText.errorMessages.limitedPartnership.term.termRequired
+          }
+        ]
+      });
+    });
+
+    it("should return an error if term is empty", () => {
+      const limitedPartnership = new LimitedPartnership().set({}, enTranslationText);
+      const errors = limitedPartnership.runTermValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+      expect(errors.getErrors()).toEqual({
+        term: {
+          text: enTranslationText.errorMessages.limitedPartnership.term.termRequired
+        },
+        errorList: [
+          {
+            href: "#term",
+            text: enTranslationText.errorMessages.limitedPartnership.term.termRequired
+          }
+        ]
+      });
+    });
+  });
+});

--- a/src/views/pages/name/options-with-or-without-welsh.njk
+++ b/src/views/pages/name/options-with-or-without-welsh.njk
@@ -7,7 +7,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     },
     {
       value: "LP",
@@ -16,7 +16,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     },
     {
       value: "L.P.",
@@ -25,7 +25,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     }
   ]
 %}
@@ -41,7 +41,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     },
     {
       value: "PC",
@@ -50,7 +50,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     },
     {
       value: "P.C.",
@@ -59,7 +59,7 @@
       name: "name_ending",
       attributes : {
         required : true
-      }
+      } if not journeyTypes.isRegistration
     }
   ), nameEndingOptionsList) %}
 

--- a/src/views/partnership-name.njk
+++ b/src/views/partnership-name.njk
@@ -73,7 +73,7 @@
             required : true,
             "aria-describedby": "partnership_name-hint",
             minLength: "1"
-          },
+          } if not journeyTypes.isRegistration,
           suffix: {
             text: "Limited Partnership"
           }

--- a/src/views/partnership-type.njk
+++ b/src/views/partnership-type.njk
@@ -15,8 +15,8 @@
 
         {{ govukRadios({
           classes: "govuk-radios",
-          name: "parameter",
-          errorMessage: props.errors.parameter if props.errors.parameter,
+          name: "partnership_type",
+          errorMessage: props.errors.partnershipType if props.errors.partnershipType,
           fieldset: {
             legend: {
               text: i18n.partnershipTypePage.title,


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1230


### Change description
New LimitedPartnershipValidator
validate name page + name ending radio buttons
move term validation to partnership validator
move partnership type validation to partnership validator


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.