### PR TITLE
Add limitedPartnership confirm pages to isConfirmAddressPageType

### DIFF
--- a/src/presentation/controller/addressLookUp/PageType.ts
+++ b/src/presentation/controller/addressLookUp/PageType.ts
@@ -156,6 +156,13 @@ export const PERSON_WITH_SIGNIFICANT_CONTROL_PAGES: Set<PageType | PageDefault> 
   AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress
 ]);
 
+export const isConfirmLimitedPartnershipAddressPageType = (pageType: string): boolean => {
+  return [
+    AddressPageType.confirmRegisteredOfficeAddress,
+    AddressPageType.confirmPrincipalPlaceOfBusinessAddress
+  ].includes(pageType as AddressPageType);
+};
+
 export const isConfirmGeneralPartnerAddressPageType = (pageType: string): boolean => {
   return [
     AddressPageType.confirmGeneralPartnerUsualResidentialAddress,
@@ -180,6 +187,7 @@ export const isConfirmPersonWithSignificantControlAddressPageType = (pageType: s
 
 export const isConfirmAddressPageType = (pageType: string): boolean => {
   return (
+    isConfirmLimitedPartnershipAddressPageType(pageType) ||
     isConfirmGeneralPartnerAddressPageType(pageType) ||
     isConfirmLimitedPartnerAddressPageType(pageType) ||
     isConfirmPersonWithSignificantControlAddressPageType(pageType)


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1870


### Change description
Change involves adding limited partnership confirm pages to the isConfirmAddressPageType arrow function, to ensure we are redirected to the enter manual address page from the confirm page if the address is missing any mandatory fields (i.e. there are errors) usually seen with partial address'


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.