### PR TITLE
Lp 1766 psc changes cya page

### DIFF
--- a/src/application/service/utils.ts
+++ b/src/application/service/utils.ts
@@ -36,14 +36,16 @@ export const incompletePersonWithSignificantControlErrorList = (
   i18n: Record<string, any>
 ): Record<string, string> => {
   let errorList = {};
+  const beforeName = i18n?.personWithSignificantControl?.reviewPage?.errorMessage?.beforeName ?? "";
+  const afterName = i18n?.personWithSignificantControl?.reviewPage?.errorMessage?.afterName ?? "";
 
-  personsWithSignificantControl
+  (personsWithSignificantControl || [])
     .filter((psc) => psc?.data?.completed === false)
     .forEach((psc) => {
       const name = psc.data?.forename ? `${psc.data.forename} ${psc.data.surname}` : psc.data?.legal_entity_name ?? "";
       errorList = {
         ...errorList,
-        [name.toLowerCase()]: `${i18n.personWithSignificantControl.reviewPage.errorMessage.beforeName} ${name} ${i18n.personWithSignificantControl.reviewPage.errorMessage.afterName}`
+        [name.toLowerCase()]: `${beforeName} ${name} ${afterName}`.trim()
       };
     });
   return errorList;

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -124,7 +124,10 @@ class LimitedPartnershipController extends PartnershipController {
     const { personsWithSignificantControl } =
         await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, transactionId);
 
-    const sortedPersonsWithSignificantControl = this.sortPscByType(personsWithSignificantControl);
+    const sortedPersonsWithSignificantControl =
+      personsWithSignificantControl?.length
+        ? this.sortPscByType(personsWithSignificantControl)
+        : personsWithSignificantControl;
 
     return { generalPartners, limitedPartners, personsWithSignificantControl: sortedPersonsWithSignificantControl };
   }

--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -7,6 +7,7 @@ import {
   PartnershipType,
   PersonWithSignificantControl
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { PersonWithSignificantControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
 import PaymentService from "../../../application/service/PaymentService";
@@ -114,15 +115,27 @@ class LimitedPartnershipController extends PartnershipController {
     limitedPartners: LimitedPartner[];
     personsWithSignificantControl: PersonWithSignificantControl[];
   }> {
-    if (pageRouting.pageType === RegistrationPageType.checkYourAnswers) {
-      const { generalPartners } = await this.generalPartnerService.getGeneralPartners(tokens, transactionId);
-      const { limitedPartners } = await this.limitedPartnerService.getLimitedPartners(tokens, transactionId);
-      const { personsWithSignificantControl } =
+    if (pageRouting.pageType !== RegistrationPageType.checkYourAnswers) {
+      return { generalPartners: [], limitedPartners: [], personsWithSignificantControl: [] };
+    }
+
+    const { generalPartners } = await this.generalPartnerService.getGeneralPartners(tokens, transactionId);
+    const { limitedPartners } = await this.limitedPartnerService.getLimitedPartners(tokens, transactionId);
+    const { personsWithSignificantControl } =
         await this.personWithSignificantControlService.getPersonsWithSignificantControl(tokens, transactionId);
 
-      return { generalPartners, limitedPartners, personsWithSignificantControl };
-    }
-    return { generalPartners: [], limitedPartners: [], personsWithSignificantControl: [] };
+    const sortedPersonsWithSignificantControl = this.sortPscByType(personsWithSignificantControl);
+
+    return { generalPartners, limitedPartners, personsWithSignificantControl: sortedPersonsWithSignificantControl };
+  }
+
+  private sortPscByType(personsWithSignificantControl: PersonWithSignificantControl[]): PersonWithSignificantControl[] {
+    // Group into three arrays (preserves original order within each group)
+    const individuals = personsWithSignificantControl.filter(p => p?.data?.type === PersonWithSignificantControlType.INDIVIDUAL_PERSON);
+    const legalEntities = personsWithSignificantControl.filter(p => p?.data?.type === PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY);
+    const otherRegistrables = personsWithSignificantControl.filter(p => p?.data?.type === PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON);
+
+    return [...individuals, ...legalEntities, ...otherRegistrables];
   }
 
   private async renderCheckYourAnswersWithLawfulPurposeError(request: Request, response: Response) {

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -560,21 +560,29 @@ describe("Check Your Answers Page", () => {
       expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.changeRemoveOrAdd);
     });
 
-    it("should render the Individual Person PSC correctly", async () => {
-      const psc = new PersonWithSignificantControlBuilder().isIndividualPerson().build();
-      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([psc]);
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])(
+      "should render the Individual Person PSC correctly in %s",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        setLocalesEnabled(true);
 
-      const res = await request(app).get(URL);
+        const psc = new PersonWithSignificantControlBuilder().isIndividualPerson().build();
+        appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([psc]);
 
-      expect(res.status).toBe(200);
-      expect(res.text).toContain(psc.data?.title);
-      expect(res.text).toContain(psc.data?.forename);
-      expect(res.text).toContain(psc.data?.middle_names);
-      expect(res.text).toContain(psc.data?.surname);
-      expect(res.text).toContain(formatDate(psc.data?.date_of_birth as string, enTranslationText));
-      expect(res.text).toContain(psc.data?.nationality1);
-      expect(res.text).toContain(psc.data?.nationality2);
-    });
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(psc.data?.title);
+        expect(res.text).toContain(psc.data?.forename);
+        expect(res.text).toContain(psc.data?.middle_names);
+        expect(res.text).toContain(psc.data?.surname);
+        expect(res.text).toContain(formatDate(psc.data?.date_of_birth as string, translationText));
+        expect(res.text).toContain(psc.data?.nationality1);
+        expect(res.text).toContain(psc.data?.nationality2);
+      }
+    );
 
     it("should render the PSCs in the correct order", async () => {
       const rle = new PersonWithSignificantControlBuilder().withId("rle-id").isRelevantLegalEntity().build();

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -559,6 +559,53 @@ describe("Check Your Answers Page", () => {
       expect(res.text).toContain(enTranslationText.checkYourAnswersPage.psc.noPscStatement);
       expect(res.text).not.toContain(enTranslationText.checkYourAnswersPage.psc.changeRemoveOrAdd);
     });
+
+    it("should render the Individual Person PSC correctly", async () => {
+      const psc = new PersonWithSignificantControlBuilder().isIndividualPerson().build();
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([psc]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(psc.data?.title);
+      expect(res.text).toContain(psc.data?.forename);
+      expect(res.text).toContain(psc.data?.middle_names);
+      expect(res.text).toContain(psc.data?.surname);
+      expect(res.text).toContain(formatDate(psc.data?.date_of_birth as string, enTranslationText));
+      expect(res.text).toContain(psc.data?.nationality1);
+      expect(res.text).toContain(psc.data?.nationality2);
+    });
+
+    it("should render the PSCs in the correct order", async () => {
+      const rle = new PersonWithSignificantControlBuilder().withId("rle-id").isRelevantLegalEntity().build();
+      const orp = new PersonWithSignificantControlBuilder().withId("orp-id").isOtherRegistrablePerson().build();
+      const individual = new PersonWithSignificantControlBuilder().withId("individual-id").isIndividualPerson().build();
+
+      const rleName = "PSC_ORDER_RLE";
+      const orpName = "PSC_ORDER_ORP";
+      const individualForename = "PSC_ORDER_INDIVIDUAL_FORENAME";
+      rle.data!.legal_entity_name = rleName;
+      orp.data!.legal_entity_name = orpName;
+      individual.data!.forename = individualForename;
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([rle, orp, individual]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+
+      const rleIndex = res.text.indexOf(rleName);
+      const orpIndex = res.text.indexOf(orpName);
+      const individualIndex = res.text.indexOf(individualForename);
+
+      expect(rleIndex).toBeGreaterThan(-1);
+      expect(orpIndex).toBeGreaterThan(-1);
+      expect(individualIndex).toBeGreaterThan(-1);
+
+      expect(individualIndex).toBeLessThan(orpIndex);
+      expect(rleIndex).toBeLessThan(orpIndex);
+    });
+
   });
 
   describe("POST Check Your Answers Page", () => {

--- a/src/views/pages/checkYourAnswers/person-with-significant-control.njk
+++ b/src/views/pages/checkYourAnswers/person-with-significant-control.njk
@@ -1,6 +1,16 @@
 {% set isRle = item.data.type === "RELEVANT_LEGAL_ENTITY" %}
+{% set isOrp = item.data.type === "OTHER_REGISTRABLE_PERSON" %}
+{% set isIp = item.data.type === "INDIVIDUAL_PERSON" %}
+
 {% if isRle and item.data.legal_entity_registration_location %}
   {% set country = i18n.countries[macros.makeCamelCase(item.data.legal_entity_registration_location)] %}
+{% endif %}
+
+{% if isIp %}
+  {% set nationalities = macros.formatNationality(item.data.nationality1, i18n) %}
+  {% if item.data.nationality2 %}
+    {% set nationalities = macros.formatNationality(item.data.nationality1, i18n) + ", " + macros.formatNationality(item.data.nationality2, i18n) %}
+  {% endif %}
 {% endif %}
 
 {{ govukSummaryList({
@@ -8,12 +18,53 @@
   rows: [
     {
       key: {
+        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.personTitle
+      },
+      value: {
+        text: item.data.title
+      }
+    } if isIp and item.data.title,
+    {
+      key: {
+        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.firstName
+      },
+      value: {
+        text: item.data.forename
+      }
+    } if isIp,
+    {
+      key: {
+        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.middleNames
+      },
+      value: {
+        text: item.data.middle_names
+      }
+    } if isIp and item.data.middle_names,
+    {
+      key: {
+        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.lastName
+      },
+      value: {
+        text: item.data.surname
+      }
+    } if isIp,
+    SET_DATE_OF_BIRTH_SECTION(item, i18n) if isIp,
+     {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.person.nationality
+      },
+      value: {
+        text: nationalities
+      }
+    } if isIp,
+    {
+      key: {
         text: i18n.checkYourAnswersPage.partners.legalEntity.name
       },
       value: {
         text: item.data.legal_entity_name
       }
-    },
+    } if isRle or isOrp,
     {
       key: {
         text: i18n.checkYourAnswersPage.partners.legalEntity.legalForm
@@ -21,7 +72,7 @@
       value: {
         text: item.data.legal_form
       }
-    },
+    } if isRle or isOrp,
     {
       key: {
         text: i18n.checkYourAnswersPage.partners.legalEntity.governingLaw
@@ -29,7 +80,7 @@
       value: {
         text: item.data.governing_law
       }
-    },
+    } if isRle or isOrp,
     {
       key: {
         text: i18n.checkYourAnswersPage.partners.legalEntity.register
@@ -56,11 +107,28 @@
     } if isRle,
     {
       key: {
+        text: i18n.checkYourAnswersPage.partners.person.usualResidentialAddress
+      },
+      value: {
+        text: macros.formatAddress(item.data.usual_residential_address, true, i18n)
+      }
+    } if isIp and item.data.usual_residential_address,
+    {
+      key: {
+        text: i18n.checkYourAnswersPage.partners.person.correspondenceAddress
+      },
+      value: {
+        text: macros.formatAddress(item.data.service_address, true, i18n)
+      }
+    } if isIp and item.data.service_address,
+    {
+      key: {
         text: i18n.checkYourAnswersPage.partners.legalEntity.principalOfficeAddress
       },
       value: {
         text: macros.formatAddress(item.data.principal_office_address, true, i18n)
       }
-    }
+    } if isRle or isOrp
+
   ]
 }) }}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1766


### Change description
This pull request enhances how Persons With Significant Control (PSC) are handled and displayed on the "Check Your Answers" page, with a focus on correctly rendering individual PSCs and ensuring PSCs are shown in the required order. It also adds comprehensive integration tests for these improvements and makes some utility and template refinements for clarity and maintainability.

Key changes include:

**PSC Display and Ordering Improvements:**

* Added logic in `LimitedPartnershipController` to sort PSCs so that Individual Persons appear first, followed by Relevant Legal Entities, then Other Registrable Persons. This ensures the correct display order on the summary page.
* Updated the PSC summary template (`person-with-significant-control.njk`) to render all relevant fields for Individual Person PSCs, including title, names, date of birth, nationalities, and addresses, while maintaining correct rendering for other PSC types. [[1]](diffhunk://#diff-5c6eaa7309c5b180db8aeb5f4356d753b79fcbf3ce68cb04c7ee2eaf7c50df5fR2-R83) [[2]](diffhunk://#diff-5c6eaa7309c5b180db8aeb5f4356d753b79fcbf3ce68cb04c7ee2eaf7c50df5fR108-R132)

**Testing Enhancements:**

* Added integration tests to verify that Individual Person PSCs are rendered with all required fields and that PSCs are displayed in the correct order on the Check Your Answers page.

**Utility and Code Quality Improvements:**

* Refactored `incompletePersonWithSignificantControlErrorList` to improve readability and handle missing PSC lists gracefully.
* Imported `PersonWithSignificantControlType` where needed for improved type safety and clarity.

These changes ensure that PSCs are displayed accurately and consistently, and that the application logic and tests are aligned with business rules and user expectations.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.