### PR TITLE
Lp 1957 allow todays date in gateway validation

### DIFF
--- a/src/domain/validator/DateValidators.ts
+++ b/src/domain/validator/DateValidators.ts
@@ -13,7 +13,7 @@ export type DateErrorMessages = {
   yearInvalidLength: string;
 }
 
-const parseDateParts = (day: string, month: string, year: string): { y: number; m: number; d: number } | null => {
+const parseDateParts = (day: string, month: string, year: string): { d: number; m: number; y: number } | null => {
   // months are 0-indexed in JavaScript Date, so we need to subtract 1 from the month
   const y = Number(year);
   const m = Number(month) - 1;
@@ -23,7 +23,7 @@ const parseDateParts = (day: string, month: string, year: string): { y: number; 
     return null;
   }
 
-  return { y, m, d };
+  return { d, m, y };
 };
 
 export const hasMissingDateFields = (day: string, month: string, year: string, fieldId: string, uiErrors: UIErrors, errorMessages: DateErrorMessages): boolean => {
@@ -90,7 +90,7 @@ export const isValidDate = (day: string, month: string, year: string): boolean =
     return false;
   }
 
-  const { y, m, d } = parsedDateParts;
+  const { d, m, y } = parsedDateParts;
 
   // handles leap years as well
   const parsedDate = new Date(y, m, d);
@@ -128,7 +128,7 @@ export const isDateInPast = (day: string, month: string, year: string): boolean 
     return false;
   }
 
-  const { y, m, d } = parsedDateParts;
+  const { d, m, y } = parsedDateParts;
 
   // use UTC to deal with daylight savings and timezones; compare date-only at UTC midnight
   const targetUtcMidnight = Date.UTC(y, m, d);
@@ -145,7 +145,7 @@ export const isDateToday = (day: string, month: string, year: string): boolean =
     return false;
   }
 
-  const { y, m, d } = parsedDateParts;
+  const { d, m, y } = parsedDateParts;
 
   // use UTC to deal with daylight savings and timezones; compare date-only at UTC midnight
   const targetUtcMidnight = Date.UTC(y, m, d);

--- a/src/domain/validator/DateValidators.ts
+++ b/src/domain/validator/DateValidators.ts
@@ -13,6 +13,19 @@ export type DateErrorMessages = {
   yearInvalidLength: string;
 }
 
+const parseDateParts = (day: string, month: string, year: string): { y: number; m: number; d: number } | null => {
+  // months are 0-indexed in JavaScript Date, so we need to subtract 1 from the month
+  const y = Number(year);
+  const m = Number(month) - 1;
+  const d = Number(day);
+
+  if ([y, m, d].some(Number.isNaN)) {
+    return null;
+  }
+
+  return { y, m, d };
+};
+
 export const hasMissingDateFields = (day: string, month: string, year: string, fieldId: string, uiErrors: UIErrors, errorMessages: DateErrorMessages): boolean => {
   if (!day?.trim() && !month?.trim() && !year?.trim()) {
     uiErrors.setWebError(fieldId, errorMessages?.dateMissing);
@@ -71,13 +84,13 @@ export const hasInvalidDateFieldLengths = (day: string, month: string, year: str
 };
 
 export const isValidDate = (day: string, month: string, year: string): boolean => {
-  // months are 0-indexed in JavaScript Date, so we need to subtract 1 from the month
-  const y = Number(year);
-  const m = Number(month) - 1;
-  const d = Number(day);
-  if ([y, m, d].some(Number.isNaN)) {
+  const parsedDateParts = parseDateParts(day, month, year);
+
+  if (!parsedDateParts) {
     return false;
   }
+
+  const { y, m, d } = parsedDateParts;
 
   // handles leap years as well
   const parsedDate = new Date(y, m, d);
@@ -89,7 +102,7 @@ export const isValidDate = (day: string, month: string, year: string): boolean =
   );
 };
 
-export const isValidDateStringAndInPast = (date: string): boolean => {
+export const isValidDateStringAndNotInFuture = (date: string): boolean => {
   const [year, month, day] = date.split("-");
   const isDayInvalid = day.length > 2;
   const isMonthInvalid = month.length > 2;
@@ -102,20 +115,20 @@ export const isValidDateStringAndInPast = (date: string): boolean => {
   if (!isValidDate(day, month, year)) {
     return false;
   }
-  if (!isDateInPast(day, month, year)) {
+  if (!isDateInPast(day, month, year) && !isDateToday(day, month, year)) {
     return false;
   }
   return true;
 };
 
 export const isDateInPast = (day: string, month: string, year: string): boolean => {
-  // months are 0-indexed in JavaScript Date, so we need to subtract 1 from the month
-  const y = Number(year);
-  const m = Number(month) - 1;
-  const d = Number(day);
-  if ([y, m, d].some(Number.isNaN)) {
+  const parsedDateParts = parseDateParts(day, month, year);
+
+  if (!parsedDateParts) {
     return false;
   }
+
+  const { y, m, d } = parsedDateParts;
 
   // use UTC to deal with daylight savings and timezones; compare date-only at UTC midnight
   const targetUtcMidnight = Date.UTC(y, m, d);
@@ -123,6 +136,23 @@ export const isDateInPast = (day: string, month: string, year: string): boolean 
   const todayUtcMidnightForLocal = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
 
   return targetUtcMidnight < todayUtcMidnightForLocal;
+};
+
+export const isDateToday = (day: string, month: string, year: string): boolean => {
+  const parsedDateParts = parseDateParts(day, month, year);
+
+  if (!parsedDateParts) {
+    return false;
+  }
+
+  const { y, m, d } = parsedDateParts;
+
+  // use UTC to deal with daylight savings and timezones; compare date-only at UTC midnight
+  const targetUtcMidnight = Date.UTC(y, m, d);
+  const now = new Date();
+  const todayUtcMidnightForLocal = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+
+  return targetUtcMidnight === todayUtcMidnightForLocal;
 };
 
 export const dateContainsInvalidChars = (day: string, month: string, year: string): boolean => {

--- a/src/infrastructure/gateway/limitedPartnership/LimitedPartnershipInMemoryGateway.ts
+++ b/src/infrastructure/gateway/limitedPartnership/LimitedPartnershipInMemoryGateway.ts
@@ -9,6 +9,7 @@ import TransactionLimitedPartnership from "../../../domain/entities/TransactionL
 import LimitedPartnershipGatewayBuilder from "./LimitedPartnershipGatewayBuilder";
 import UIErrors, { ApiErrors } from "../../../domain/entities/UIErrors";
 import PageType from "../../../presentation/controller/PageType";
+import { validateAndFormatPartnerDateOfUpdate } from "../utils";
 
 class LimitedPartnershipInMemoryGateway implements ILimitedPartnershipGateway {
   submissionId = crypto.randomUUID().toString();
@@ -76,6 +77,8 @@ class LimitedPartnershipInMemoryGateway implements ILimitedPartnershipGateway {
     registrationPageType: RegistrationPageType,
     data: Record<string, any>
   ): Promise<void> {
+    validateAndFormatPartnerDateOfUpdate(data);
+    
     if (this.uiErrors?.hasErrors()) {
       throw this.uiErrors;
     }

--- a/src/infrastructure/gateway/utils.ts
+++ b/src/infrastructure/gateway/utils.ts
@@ -1,5 +1,5 @@
 import UIErrors from "../../domain/entities/UIErrors";
-import { isValidDateStringAndInPast } from "../../domain/validator/DateValidators";
+import { isValidDateStringAndNotInFuture } from "../../domain/validator/DateValidators";
 
 export const convertValidDateToIsoDateString = (
   date: { day: string; month: string; year: string },
@@ -7,7 +7,7 @@ export const convertValidDateToIsoDateString = (
 ): string => {
   const dateStr = convertDateToIsoDateString(date.day.trim(), date.month.trim(), date.year.trim());
 
-  if (!isValidDateStringAndInPast(dateStr)) {
+  if (!isValidDateStringAndNotInFuture(dateStr)) {
     const uiErrors = new UIErrors();
     uiErrors.formatValidationErrorToUiErrors({
       errors: {

--- a/src/presentation/test/integration/postTransition/limitedPartnership/dateOfUpdate/when-did-the-principal-place-of-business-address-change.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/dateOfUpdate/when-did-the-principal-place-of-business-address-change.test.ts
@@ -24,6 +24,7 @@ describe("Partnership principal place of business address change date page", () 
 
     const limitedPartnership = new LimitedPartnershipBuilder().withDateOfUpdate("2024-10-10").build();
     appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+    appDevDependencies.limitedPartnershipGateway.feedErrors([]);
   });
 
   describe("GET principal place of business address change date page", () => {
@@ -85,6 +86,20 @@ describe("Partnership principal place of business address change date page", () 
       expect(res.status).toBe(200);
       expect(res.text).not.toContain(originalErrorMessage);
       expect(res.text).toContain(expectedErrorMessage);
+    });
+
+    it("should not show validation error when submitting todays date", async () => {
+      const today = new Date();
+      const res = await request(app).post(URL).send({
+        pageType: PostTransitionPageType.whenDidThePrincipalPlaceOfBusinessAddressChange,
+        "date_of_update-day": today.getDate().toString(),
+        "date_of_update-month": (today.getMonth() + 1).toString(),
+        "date_of_update-year": today.getFullYear().toString()
+      });
+
+      const redirectUrl = getUrl(PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_CHANGE_CHECK_YOUR_ANSWERS_URL);
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${redirectUrl}`);
     });
   });
 });

--- a/src/presentation/test/unit/domain/date-validation.spec.ts
+++ b/src/presentation/test/unit/domain/date-validation.spec.ts
@@ -1,0 +1,281 @@
+import { dateContainsInvalidChars, isDateInPast, isDateToday, isValidDate, isValidDateStringAndNotInFuture } from '../../../../domain/validator/DateValidators';
+
+describe('isValidDate', () => {
+  it('returns true for a valid date', () => {
+    expect(isValidDate('21', '05', '2026')).toBe(true);
+  });
+
+  it('returns true for leap day in a leap year', () => {
+    expect(isValidDate('29', '02', '2024')).toBe(true);
+  });
+
+  it('returns false for leap day in a non-leap year', () => {
+    expect(isValidDate('29', '02', '2023')).toBe(false);
+  });
+
+  it('returns false for invalid day-month combinations', () => {
+    expect(isValidDate('31', '04', '2026')).toBe(false);
+    expect(isValidDate('31', '11', '2026')).toBe(false);
+  });
+
+  it('returns false for impossible day and month values', () => {
+    expect(isValidDate('00', '01', '2026')).toBe(false);
+    expect(isValidDate('01', '00', '2026')).toBe(false);
+    expect(isValidDate('32', '01', '2026')).toBe(false);
+    expect(isValidDate('01', '13', '2026')).toBe(false);
+  });
+
+  it('returns false for non-numeric input', () => {
+    expect(isValidDate('aa', '01', '2026')).toBe(false);
+    expect(isValidDate('01', 'bb', '2026')).toBe(false);
+    expect(isValidDate('01', '01', 'cccc')).toBe(false);
+  });
+});
+
+describe('isDateInPast', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns true for a date before today', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isDateInPast('20', '05', '2026')).toBe(true);
+  });
+
+  it('returns false for today', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isDateInPast('21', '05', '2026')).toBe(false);
+  });
+
+  it('returns false for a future date', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isDateInPast('22', '05', '2026')).toBe(false);
+  });
+
+  it('returns false for invalid date values', () => {
+    expect(isDateInPast('32', '13', 'abcd')).toBe(false);
+  });
+
+  it('uses Date.UTC to compare date-only values', () => {
+    jest.useFakeTimers();
+    // month is zero based in JS Date, so 4 = May
+    const mockedNow = new Date(2026, 4, 21, 23, 59, 59);
+    jest.setSystemTime(mockedNow);
+    const utcSpy = jest.spyOn(Date, 'UTC');
+
+    try {
+      expect(isDateInPast('20', '05', '2026')).toBe(true);
+      expect(utcSpy).toHaveBeenNthCalledWith(1, 2026, 4, 20);
+      expect(utcSpy).toHaveBeenNthCalledWith(2, 2026, 4, 21);
+      expect(utcSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      utcSpy.mockRestore();
+    }
+  });
+
+  it('handles spring-forward day boundary without timezone drift', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 2, 29, 0, 30, 0));
+
+    expect(isDateInPast('28', '03', '2026')).toBe(true);
+    expect(isDateInPast('29', '03', '2026')).toBe(false);
+    expect(isDateInPast('30', '03', '2026')).toBe(false);
+  });
+});
+
+describe('isValidDateStringAndNotInFuture', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns true for a valid date in the past', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isValidDateStringAndNotInFuture('2026-05-20')).toBe(true);
+  });
+
+  it('returns true for today', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isValidDateStringAndNotInFuture('2026-05-21')).toBe(true);
+  });
+
+  it('returns false for a future date', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 4, 21, 10, 0, 0));
+
+    expect(isValidDateStringAndNotInFuture('2026-05-22')).toBe(false);
+  });
+
+  it('returns false for invalid date strings', () => {
+    expect(isValidDateStringAndNotInFuture('2026-02-29')).toBe(false);
+    expect(isValidDateStringAndNotInFuture('2026-04-31')).toBe(false);
+  });
+
+  it('returns false when day length is too long', () => {
+    expect(isValidDateStringAndNotInFuture('2026-05-021')).toBe(false);
+  });
+
+  it('returns false when month length is too long', () => {
+    expect(isValidDateStringAndNotInFuture('2026-005-21')).toBe(false);
+  });
+
+  it('returns false when year length is not four', () => {
+    expect(isValidDateStringAndNotInFuture('26-05-21')).toBe(false);
+    expect(isValidDateStringAndNotInFuture('20266-05-21')).toBe(false);
+  });
+});
+
+describe('dateContainsInvalidChars', () => {
+  it('returns true when day contains non-numeric characters', () => {
+    expect(dateContainsInvalidChars('aa', '05', '2026')).toBe(true);
+  });
+
+  it('returns true when month contains non-numeric characters', () => {
+    expect(dateContainsInvalidChars('21', 'bb', '2026')).toBe(true);
+  });
+
+  it('returns true when year contains non-numeric characters', () => {
+    expect(dateContainsInvalidChars('21', '05', 'cccc')).toBe(true);
+  });
+
+  it('returns false when all values are numeric', () => {
+    expect(dateContainsInvalidChars('21', '05', '2026')).toBe(false);
+  });
+
+  it('returns false when values are empty strings', () => {
+    expect(dateContainsInvalidChars('', '', '')).toBe(false);
+  });
+});
+
+describe('isDateToday', () => {
+  const today = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  it('uses Date.UTC to compare date-only values', () => {
+    jest.useFakeTimers();
+    // month is zero based in JS Date, so 4 = May
+    const mockedNow = new Date(2026, 4, 21, 23, 59, 59);
+    jest.setSystemTime(mockedNow);
+    const utcSpy = jest.spyOn(Date, 'UTC');
+
+    try {
+      expect(isDateToday('21', '05', '2026')).toBe(true);
+      expect(utcSpy).toHaveBeenNthCalledWith(1, 2026, 4, 21);
+      expect(utcSpy).toHaveBeenNthCalledWith(2, 2026, 4, 21);
+      expect(utcSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      utcSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  describe('daylight saving boundaries', () => {
+    const assertIsDateToday = (date: Date, expected: boolean) => {
+      const day = pad(date.getDate());
+      const month = pad(date.getMonth() + 1);
+      const year = date.getFullYear().toString();
+      expect(isDateToday(day, month, year)).toBe(expected);
+    };
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('handles spring-forward day at local 00:30', () => {
+      jest.useFakeTimers();
+      const now = new Date(2026, 2, 29, 0, 30, 0);
+      jest.setSystemTime(now);
+
+      const yesterday = new Date(2026, 2, 28);
+      const tomorrow = new Date(2026, 2, 30);
+
+      assertIsDateToday(now, true);
+      assertIsDateToday(yesterday, false);
+      assertIsDateToday(tomorrow, false);
+    });
+
+    it('handles spring-forward day at local 23:30', () => {
+      jest.useFakeTimers();
+      const now = new Date(2026, 2, 29, 23, 30, 0);
+      jest.setSystemTime(now);
+
+      const yesterday = new Date(2026, 2, 28);
+      const tomorrow = new Date(2026, 2, 30);
+
+      assertIsDateToday(now, true);
+      assertIsDateToday(yesterday, false);
+      assertIsDateToday(tomorrow, false);
+    });
+
+    it('handles fall-back day at local 00:30', () => {
+      jest.useFakeTimers();
+      const now = new Date(2026, 9, 25, 0, 30, 0);
+      jest.setSystemTime(now);
+
+      const yesterday = new Date(2026, 9, 24);
+      const tomorrow = new Date(2026, 9, 26);
+
+      assertIsDateToday(now, true);
+      assertIsDateToday(yesterday, false);
+      assertIsDateToday(tomorrow, false);
+    });
+
+    it('handles fall-back day at local 23:30', () => {
+      jest.useFakeTimers();
+      const now = new Date(2026, 9, 25, 23, 30, 0);
+      jest.setSystemTime(now);
+
+      const yesterday = new Date(2026, 9, 24);
+      const tomorrow = new Date(2026, 9, 26);
+
+      assertIsDateToday(now, true);
+      assertIsDateToday(yesterday, false);
+      assertIsDateToday(tomorrow, false);
+    });
+  });
+
+  it('returns true for today\'s date', () => {
+    const day = pad(today.getDate());
+    const month = pad(today.getMonth() + 1); // JS months are 0-indexed
+    const year = today.getFullYear().toString();
+    expect(isDateToday(day, month, year)).toBe(true);
+  });
+
+  it('returns false for yesterday', () => {
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    const day = pad(yesterday.getDate());
+    const month = pad(yesterday.getMonth() + 1);
+    const year = yesterday.getFullYear().toString();
+    expect(isDateToday(day, month, year)).toBe(false);
+  });
+
+  it('returns false for tomorrow', () => {
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+    const day = pad(tomorrow.getDate());
+    const month = pad(tomorrow.getMonth() + 1);
+    const year = tomorrow.getFullYear().toString();
+    expect(isDateToday(day, month, year)).toBe(false);
+  });
+
+  it('returns false for invalid date', () => {
+    expect(isDateToday('32', '13', 'abcd')).toBe(false);
+  });
+
+  it('returns false for missing fields', () => {
+    expect(isDateToday('', '', '')).toBe(false);
+    expect(isDateToday('01', '', '2020')).toBe(false);
+    expect(isDateToday('', '01', '2020')).toBe(false);
+    expect(isDateToday('01', '01', '')).toBe(false);
+  });
+});


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1957


### Change description

This pull request enhances date validation logic to allow today's date as a valid input (not just past dates) and refactors date parsing to improve code reuse and consistency. It also updates related tests and utilities to reflect this change.

**Date validation improvements:**

* Added a new helper function `parseDateParts` to centralize and simplify date parsing from string inputs, replacing repeated parsing logic throughout the validators.
* Updated `isValidDate`, `isDateInPast`, and related functions to use `parseDateParts` for consistency and maintainability. [[1]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cL74-R94) [[2]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cL105-R132) [[3]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cR141-R157)
* Introduced a new function `isDateToday` to check if a date matches the current day, and updated logic to allow today's date as valid (not just dates in the past). [[1]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cR141-R157) [[2]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cL105-R132)

**API and utility changes:**

* Renamed `isValidDateStringAndInPast` to `isValidDateStringAndNotInFuture` and updated its logic to accept today's date as valid. Updated all usages accordingly, including in `convertValidDateToIsoDateString`. [[1]](diffhunk://#diff-497d29fcf61638217cf86f0e3674e5b885532ea75311a072e08aae5d36c7f81cL92-R105) [[2]](diffhunk://#diff-eee5d4e6b17640e50474302f9010ac8af04f5322fa8414ed351d0b4b95cc22baL2-R10)

**Test and integration improvements:**

* Added an integration test to verify that submitting today's date does not trigger a validation error.
* Minor test setup improvements to clear errors before each test.

**Gateway update:**

* Ensured `validateAndFormatPartnerDateOfUpdate` is called in the in-memory gateway to validate dates using the updated logic. [[1]](diffhunk://#diff-a1668215a3b9142be631089169caa6dcc7ab54f3332378bd67b9bdfc04c53ab9R12) [[2]](diffhunk://#diff-a1668215a3b9142be631089169caa6dcc7ab54f3332378bd67b9bdfc04c53ab9R80-R81)

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.