### PR TITLE
LP-1913 Display partnership name above page title on remove pages

### DIFF
--- a/src/presentation/test/integration/registration/generalPartner/remove-general-partner.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/remove-general-partner.test.ts
@@ -7,6 +7,7 @@ import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 
 import GeneralPartnerBuilder from "../../../builder/GeneralPartnerBuilder";
+import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import { REMOVE_GENERAL_PARTNER_URL, REVIEW_GENERAL_PARTNERS_URL } from "../../../../controller/registration/url";
 import RegistrationPageType from "../../../../controller/registration/PageType";
@@ -42,6 +43,26 @@ describe("Remove General Partner Page", () => {
       testTranslations(res.text, enTranslationText.removePartnerPage);
 
       expect(res.text).toContain(`${generalPartnerPerson?.data?.forename} ${generalPartnerPerson?.data?.surname}`);
+    });
+
+    it("should contain the partnership name above the page title", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
+
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      const generalPartnerPerson = new GeneralPartnerBuilder()
+        .isPerson()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartnerPerson]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} ${limitedPartnership?.data?.name_ending?.toUpperCase()}`
+      );
     });
 
     it("should load the remove general partners page with Welsh text", async () => {

--- a/src/presentation/test/integration/registration/limitedPartner/remove-limited-partner.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/remove-limited-partner.test.ts
@@ -7,6 +7,7 @@ import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 
 import LimitedPartnerBuilder from "../../../builder/LimitedPartnerBuilder";
+import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import { REMOVE_LIMITED_PARTNER_URL, REVIEW_LIMITED_PARTNERS_URL } from "../../../../controller/registration/url";
 import RegistrationPageType from "../../../../controller/registration/PageType";
@@ -42,6 +43,26 @@ describe("Remove Limited Partner Page", () => {
       testTranslations(res.text, enTranslationText.removePartnerPage);
 
       expect(res.text).toContain(`${limitedPartnerPerson?.data?.forename} ${limitedPartnerPerson?.data?.surname}`);
+    });
+
+    it("should contain the partnership name above the page title", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
+
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      const limitedPartnerPerson = new LimitedPartnerBuilder()
+        .isPerson()
+        .withId(appDevDependencies.limitedPartnerGateway.limitedPartnerId)
+        .build();
+
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartnerPerson]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} ${limitedPartnership?.data?.name_ending?.toUpperCase()}`
+      );
     });
 
     it("should load the remove limited partners page with Welsh text", async () => {

--- a/src/presentation/test/integration/registration/personWithSignificantControl/remove-person-with-significant-control.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/remove-person-with-significant-control.test.ts
@@ -9,6 +9,7 @@ import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 
 import PersonWithSignificantControlBuilder from "../../../builder/PersonWithSignificantControlBuilder";
+import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import {
   REMOVE_PERSON_WITH_SIGNIFICANT_CONTROL_URL,
@@ -74,6 +75,20 @@ describe("Remove Person With Significant Control Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(`${psc?.data?.legal_entity_name}`);
+    });
+
+    it("should contain the partnership name above the page title", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
+
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([pscRle]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} ${limitedPartnership?.data?.name_ending?.toUpperCase()}`
+      );
     });
   });
 

--- a/src/presentation/test/integration/transition/generalPartner/remove-general-partner.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/remove-general-partner.test.ts
@@ -7,6 +7,7 @@ import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 
 import GeneralPartnerBuilder from "../../../builder/GeneralPartnerBuilder";
+import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import { REMOVE_GENERAL_PARTNER_URL, REVIEW_GENERAL_PARTNERS_URL } from "../../../../controller/transition/url";
 import TransitionPageType from "../../../../controller/transition/PageType";
@@ -42,6 +43,26 @@ describe("Remove General Partner Page", () => {
       testTranslations(res.text, enTranslationText.removePartnerPage);
 
       expect(res.text).toContain(`${generalPartnerPerson?.data?.forename} ${generalPartnerPerson?.data?.surname}`);
+    });
+
+    it("should contain the partnership name above the page title", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
+
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      const generalPartnerPerson = new GeneralPartnerBuilder()
+        .isPerson()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartnerPerson]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} (${limitedPartnership?.data?.partnership_number?.toUpperCase()})`
+      );
     });
 
     it("should load the remove general partners page with Welsh text", async () => {

--- a/src/presentation/test/integration/transition/limitedPartner/remove-limited-partner.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/remove-limited-partner.test.ts
@@ -7,6 +7,7 @@ import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
 
 import LimitedPartnerBuilder from "../../../builder/LimitedPartnerBuilder";
+import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { getUrl, setLocalesEnabled, testTranslations } from "../../../utils";
 import { REMOVE_LIMITED_PARTNER_URL, REVIEW_LIMITED_PARTNERS_URL } from "../../../../controller/transition/url";
 import RegistrationPageType from "../../../../controller/transition/PageType";
@@ -42,6 +43,26 @@ describe("Remove Limited Partner Page", () => {
       testTranslations(res.text, enTranslationText.removePartnerPage);
 
       expect(res.text).toContain(`${limitedPartnerPerson?.data?.forename} ${limitedPartnerPerson?.data?.surname}`);
+    });
+
+    it("should contain the partnership name above the page title", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().build();
+
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      const limitedPartnerPerson = new LimitedPartnerBuilder()
+        .isPerson()
+        .withId(appDevDependencies.limitedPartnerGateway.limitedPartnerId)
+        .build();
+
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartnerPerson]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `${limitedPartnership?.data?.partnership_name?.toUpperCase()} (${limitedPartnership?.data?.partnership_number?.toUpperCase()})`
+      );
     });
 
     it("should load the remove limited partners page with Welsh text", async () => {

--- a/src/views/pages/remove-partner.njk
+++ b/src/views/pages/remove-partner.njk
@@ -6,7 +6,9 @@
 
             {% include "includes/csrf_token.njk" %}
 
-            {{ govukRadios({          
+            {% include "includes/proposed-name.njk" %}
+
+            {{ govukRadios({
                 classes: "govuk-radios--inline",
                 idPrefix: "remove",
                 name: "remove",

--- a/src/views/remove-person-with-significant-control.njk
+++ b/src/views/remove-person-with-significant-control.njk
@@ -21,6 +21,8 @@
 
         {% include "includes/csrf_token.njk" %}
 
+        {% include "includes/proposed-name.njk" %}
+
         {{ govukRadios({
             classes: "govuk-radios--inline",
             idPrefix: "remove",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1913

### Change description

Adds the partnership name (rendered via the existing `includes/proposed-name.njk` partial) above the page title on the following pages:

- Remove partner page — General Partner and Limited Partner — for both Registration and Transition journeys (`src/views/pages/remove-partner.njk`)
- Remove PSC page — Registration only (`src/views/remove-person-with-significant-control.njk`)

Controllers already pass `limitedPartnership` into props and `journeyTypes` is set in `res.locals` by middleware, so no controller changes were needed — the existing partial handles the per-journey formatting.

Integration tests updated to assert the partnership name renders on each affected page.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria