### PR TITLE
LP-1229 Fix missing inline validation error on partnership type page

### DIFF
--- a/src/presentation/controller/registration/LimitedPartnershipController.ts
+++ b/src/presentation/controller/registration/LimitedPartnershipController.ts
@@ -340,6 +340,7 @@ class LimitedPartnershipController extends PartnershipController {
   redirectAndCacheSelection() {
     return (request: Request, response: Response, next: NextFunction) => {
       try {
+        this.limitedPartnershipService.setI18n(response.locals.i18n);
         const pageType = super.extractPageTypeOrThrowError(request, RegistrationPageType);
         const pageRouting = super.getRouting(registrationsRouting, pageType, request);
 
@@ -350,7 +351,7 @@ class LimitedPartnershipController extends PartnershipController {
         if (uiErrors.hasErrors()) {
           return response.render(
             super.templateName(pageRouting.currentUrl),
-            super.makeProps(pageRouting, {}, uiErrors)
+            super.makeProps(pageRouting, { limitedPartnership: { data: request.body } }, uiErrors)
           );
         }
 

--- a/src/presentation/test/integration/registration/which-type.test.ts
+++ b/src/presentation/test/integration/registration/which-type.test.ts
@@ -19,7 +19,7 @@ import {
   APPLICATION_CACHE_KEY_PREFIX_REGISTRATION,
   SERVICE_NAME_REGISTRATION
 } from "../../../../config/constants";
-import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { expectErrorSummaryAndInlineError, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import LimitedPartnershipBuilder from "../../../../presentation/test/builder/LimitedPartnershipBuilder";
 
 describe("Which type Page", () => {
@@ -134,7 +134,7 @@ describe("Which type Page", () => {
     ["English", "en", enTranslationText, enErrorMessages],
     ["Welsh", "cy", cyTranslationText, cyErrorMessages]
   ])(
-    "should re-render the page with an error summary in %s when no partnership type is selected",
+    "should re-render the page with an error summary and inline error in %s when no partnership type is selected",
     async (
       _description: string,
       lang: string,
@@ -149,15 +149,16 @@ describe("Which type Page", () => {
           pageType: RegistrationPageType.partnershipType
         });
 
+      const message = errorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired;
+
       expect(res.status).toBe(200);
-      expect(res.text).toContain(errorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
-      expect(res.text).toContain('href="#partnership_type"');
       expect(res.text).toContain(translationText.govUk.error.title);
+      expectErrorSummaryAndInlineError(res.text, "partnership_type", message);
       expect(appDevDependencies.cacheRepository.cache).toBeNull();
     }
   );
 
-  it("should re-render the page with an error summary when an invalid partnership type is submitted", async () => {
+  it("should re-render the page with an error summary and inline error when an invalid partnership type is submitted", async () => {
     setLocalesEnabled(true);
 
     const res = await request(app)
@@ -167,9 +168,10 @@ describe("Which type Page", () => {
         partnership_type: "INVALID"
       });
 
+    const message = enErrorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired;
+
     expect(res.status).toBe(200);
-    expect(res.text).toContain(enErrorMessages.errorMessages.limitedPartnership.partnershipType.typeRequired);
-    expect(res.text).toContain('href="#partnership_type"');
+    expectErrorSummaryAndInlineError(res.text, "partnership_type", message);
     expect(appDevDependencies.cacheRepository.cache).toBeNull();
   });
 });

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -98,6 +98,16 @@ export const countOccurrences = (text: string, target: string): number => {
   return text.split(target).length - 1;
 };
 
+export const expectErrorSummaryAndInlineError = (
+  html: string,
+  field: string,
+  message: string
+) => {
+  expect(html).toContain(`<a href="#${field}">${message}</a>`);
+  expect(html).toContain(`id="${field}-error"`);
+  expect(countOccurrences(html, message)).toBeGreaterThanOrEqual(2);
+};
+
 export const expectChangeLinks = (text: string, changeLink: string[]) => {
   changeLink.forEach((link) => {
     expect(text).toContain(getUrl(link));

--- a/src/views/partnership-type.njk
+++ b/src/views/partnership-type.njk
@@ -16,7 +16,7 @@
         {{ govukRadios({
           classes: "govuk-radios",
           name: "partnership_type",
-          errorMessage: props.errors.partnershipType if props.errors.partnershipType,
+          errorMessage: props.errors.partnership_type if props.errors.partnership_type,
           fieldset: {
             legend: {
               text: i18n.partnershipTypePage.title,


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1229


### Change description
The inline GDS error message on the 'Which type of partnership do you want to register?' page stopped rendering after the validator refactor. The template referenced props.errors.partnershipType but the validator emits the error under the snake_case key partnership_type, so the inline lookup always returned undefined and only the error summary showed. The same refactor also dropped the setI18n call from redirectAndCacheSelection, leaving the error message text empty when the service had no prior i18n.

Align the template key with the validator output, restore setI18n on the POST handler, and pass limitedPartnership data through on the error path to preserve radio state on re-render.

Strengthen the which-type integration tests to assert both the GDS summary link and the inline govuk-error-message render with the expected text, so a future key mismatch is caught instead of silently hiding the inline error.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.