### PR TITLE
Lp 1764 add correspondence address psc individual

### DIFF
--- a/locales/cy/address.json
+++ b/locales/cy/address.json
@@ -35,6 +35,11 @@
                 "title": "WELSH - Choose the PSC's usual residential address",
                 "publicRegisterInformationLine1": "WELSH - We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterInformationLine2": "WELSH - We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "WELSH - Choose the PSC's correspondence address",
+                "titleHint": "WELSH - This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                "publicRegisterInformationLine1": "WELSH - We'll show the PSC's correspondence address on the public register."
             }
         },
 
@@ -76,6 +81,10 @@
                 "title": "WELSH - Confirm the PSC's usual residential address",
                 "publicRegisterLine1": "WELSH - We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterLine2": "WELSH - We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "WELSH - Confirm the PSC's correspondence address",
+                "publicRegisterLine1": "WELSH - We'll show the PSC's correspondence address on the public register."
             }
         },
 
@@ -135,6 +144,12 @@
                     "hint": "WELSH - This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                     "publicRegisterLine1": "WELSH - We'll show the PSC's country/state of residence on the public register.",
                     "publicRegisterLine2": "WELSH - We will not show the PSC's full usual residential address on the public register.",
+                    "postcodeOptional": "WELSH - Postcode (optional)"
+                },
+                "correspondenceAddress": {
+                    "title": "WELSH - What is the PSC's correspondence address?",
+                    "titleHint": "WELSH - This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                    "publicInformationLine1": "WELSH - We'll show the PSC's correspondence address on the public register.",
                     "postcodeOptional": "WELSH - Postcode (optional)"
                 }
             },
@@ -209,6 +224,11 @@
                     "hint": "WELSH - This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                     "publicRegisterLine1": "WELSH - We'll show the PSC's country/state of residence on the public register.",
                     "publicRegisterLine2": "WELSH - We will not show the PSC's full usual residential address on the public register."
+                },
+                "correspondenceAddress": {
+                    "whatIsCorrespondenceAddress": "WELSH - What is the PSC's correspondence address?",
+                    "titleHint": "WELSH - This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                    "publicRegisterLine1": "WELSH - We'll show the PSC's correspondence address on the public register."
                 }
             },
 
@@ -264,6 +284,11 @@
                 "titleHint": "WELSH - This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                 "publicRegisterInformationLine1": "WELSH - We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterInformationLine2": "WELSH - We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "WELSH - Where is the PSC's correspondence address?",
+                "titleHint": "WELSH - This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                "publicRegisterInformationLine1": "WELSH - We'll show the PSC's correspondence address on the public register."
             }
         },
 

--- a/locales/en/address.json
+++ b/locales/en/address.json
@@ -37,6 +37,11 @@
                 "title": "Choose the PSC's usual residential address",
                 "publicRegisterInformationLine1": "We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterInformationLine2": "We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "Choose the PSC's correspondence address",
+                "titleHint": "This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                "publicRegisterInformationLine1": "We'll show the PSC's correspondence address on the public register."
             }
         },
 
@@ -78,6 +83,10 @@
                 "title": "Confirm the PSC's usual residential address",
                 "publicRegisterLine1": "We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterLine2": "We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "Confirm the PSC's correspondence address",
+                "publicRegisterLine1": "We'll show the PSC's correspondence address on the public register."
             }
         },
 
@@ -136,6 +145,12 @@
                     "hint": "This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                     "publicRegisterLine1": "We'll show the PSC's country/state of residence on the public register.",
                     "publicRegisterLine2": "We will not show the PSC's full usual residential address on the public register.",
+                    "postcodeOptional": "Postcode (optional)"
+                },
+                "correspondenceAddress": {
+                    "title": "What is the PSC's correspondence address?",
+                    "titleHint": "This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                    "publicInformationLine1": "We'll show the PSC's correspondence address on the public register.",
                     "postcodeOptional": "Postcode (optional)"
                 }
             },
@@ -210,6 +225,11 @@
                     "hint": "This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                     "publicRegisterLine1": "We'll show the PSC's country/state of residence on the public register.",
                     "publicRegisterLine2": "We will not show the PSC's full usual residential address on the public register."
+                },
+                "correspondenceAddress": {
+                    "whatIsCorrespondenceAddress": "What is the PSC's correspondence address?",
+                    "titleHint": "This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                    "publicRegisterLine1": "We'll show the PSC's correspondence address on the public register."
                 }
             },
 
@@ -265,6 +285,11 @@
                 "titleHint": "This address cannot be a PO box, DX or LP (Legal Post in Scotland) number.",
                 "publicRegisterInformationLine1": "We'll show the PSC's country/state of residence on the public register.",
                 "publicRegisterInformationLine2": "We will not show the PSC's full usual residential address on the public register."
+            },
+            "personWithSignificantControlCorrespondenceAddress": {
+                "title": "Where is the PSC's correspondence address?",
+                "titleHint": "This is also known as the service address. It should not be a home address, unless the PSC has given permission for their home address to be made public.",
+                "publicRegisterInformationLine1": "We'll show the PSC's correspondence address on the public register."
             }
         },
 

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -44,7 +44,7 @@ import GeneralPartnerService from "../../../application/service/GeneralPartnerSe
 import LimitedPartnerService from "../../../application/service/LimitedPartnerService";
 import PersonWithSignificantControlService from "../../../application/service/PersonWithSignificantControlService";
 
-import { CONFIRM_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_URL } from "./url/registration";
+import { CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL, CONFIRM_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_URL } from "./url/registration";
 import { REVIEW_GENERAL_PARTNERS_URL } from "../registration/url";
 import {
   UPDATE_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_YES_NO_URL,
@@ -681,6 +681,18 @@ class AddressLookUpController extends AbstractController {
         ids.transactionId,
         ids.submissionId
       );
+    }
+
+    if (pageRouting.pageType === AddressLookUpPageType.confirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress) {
+      const personWithSignificantControl = await this.personWithSignificantControlService.getPersonWithSignificantControl(
+        tokens,
+        ids.transactionId,
+        ids.personWithSignificantControlId
+      );
+      if (personWithSignificantControl?.data?.service_address) {
+        pageRouting.nextUrl = super.insertIdsInUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL, ids, request.url);
+        return;
+      }
     }
 
     if (pageRouting.pageType === AddressLookUpPageType.confirmRegisteredOfficeAddress) {

--- a/src/presentation/controller/addressLookUp/PageType.ts
+++ b/src/presentation/controller/addressLookUp/PageType.ts
@@ -106,6 +106,7 @@ export const MANUAL_PAGES: Set<PageType | PageDefault> = new Set([
   AddressPageType.enterPersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
   AddressPageType.enterPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
   AddressPageType.enterPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
+  AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress
 ]);
 
 export const isManualAddressPageType = (pageType: string): boolean => {
@@ -122,7 +123,8 @@ export const CHOOSE_PAGES: Set<PageType | PageDefault> = new Set([
   AddressPageType.chooseLimitedPartnerPrincipalOfficeAddress,
   AddressPageType.choosePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
   AddressPageType.choosePersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
-  AddressPageType.choosePersonWithSignificantControlIndividualPersonUsualResidentialAddress
+  AddressPageType.choosePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
+  AddressPageType.choosePersonWithSignificantControlIndividualPersonCorrespondenceAddress
 ]);
 
 export const GENERAL_PARTNER_PAGES: Set<PageType | PageDefault> = new Set([
@@ -175,7 +177,13 @@ export const PERSON_WITH_SIGNIFICANT_CONTROL_PAGES: Set<PageType | PageDefault> 
   AddressPageType.postcodePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
   AddressPageType.enterPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
   AddressPageType.choosePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
-  AddressPageType.confirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress
+  AddressPageType.confirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
+
+  AddressPageType.territoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  AddressPageType.postcodePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  AddressPageType.choosePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  AddressPageType.confirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress
 ]);
 
 export const isConfirmLimitedPartnershipAddressPageType = (pageType: string): boolean => {
@@ -204,7 +212,8 @@ export const isConfirmPersonWithSignificantControlAddressPageType = (pageType: s
   return [
     AddressPageType.confirmPersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
     AddressPageType.confirmPersonWithSignificantControlOtherRegistrablePersonPrincipalOfficeAddress,
-    AddressPageType.confirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress
+    AddressPageType.confirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
+    AddressPageType.confirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress
   ].includes(pageType as AddressPageType);
 };
 

--- a/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
@@ -1,6 +1,8 @@
 import AddressPageType from "../../PageType";
 import {
+  CHECK_YOUR_ANSWERS_URL,
   REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL,
+  WHICH_TYPE_OF_NATURE_OF_CONTROL_INDIVIDUAL_PERSON_URL,
   WHICH_TYPE_OF_NATURE_OF_CONTROL_OTHER_REGISTRABLE_PERSON_URL,
   WHICH_TYPE_OF_NATURE_OF_CONTROL_RELEVANT_LEGAL_ENTITY_URL
 } from "../../../registration/url";
@@ -151,7 +153,7 @@ const personWithSignificantControlUsualResidentialAddressCacheKeys = {
 };
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlIndividualPersonUsualResidentialAddress = {
-  previousUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
+  previousUrl: WHICH_TYPE_OF_NATURE_OF_CONTROL_INDIVIDUAL_PERSON_URL,
   currentUrl: url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
   nextUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
   pageType: AddressPageType.territoryChoicePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
@@ -210,6 +212,73 @@ const registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPer
   }
 };
 
+// Individual person correspondence address
+
+const personWithSignificantControlCorrespondenceAddressCacheKeys = {
+  [AddressCacheKeys.addressCacheKey]: "service_address",
+  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice"
+};
+
+const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress = {
+  previousUrl: url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
+  currentUrl: url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  nextUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  pageType: AddressPageType.territoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  data: {
+    ...personWithSignificantControlCorrespondenceAddressCacheKeys,
+    nextUrlOverseas: url.ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL
+  }
+};
+
+const registrationAddressRoutingPostcodePersonWithSignificantControlIndividualPersonCorrespondenceAddress = {
+  previousUrl: url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  currentUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  nextUrl: url.CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  pageType: AddressPageType.postcodePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  data: {
+    ...personWithSignificantControlCorrespondenceAddressCacheKeys,
+    enterManualAddressPageType:
+      AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+    confirmAddressUrl: url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL
+  }
+};
+
+const registrationAddressRoutingChoosePersonWithSignificantControlIndividualPersonCorrespondenceAddress = {
+  previousUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  currentUrl: url.CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  nextUrl: url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  pageType: AddressPageType.choosePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  data: {
+    ...personWithSignificantControlCorrespondenceAddressCacheKeys,
+    enterManualAddressPageType:
+      AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress
+  }
+};
+
+const registrationAddressRoutingEnterPersonWithSignificantControlIndividualPersonCorrespondenceAddress = {
+  previousUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  currentUrl: url.ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  nextUrl: url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  pageType: AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  data: {
+    ...personWithSignificantControlCorrespondenceAddressCacheKeys,
+    territoryPageType:
+      AddressPageType.territoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress
+  }
+};
+
+const registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress = {
+  previousUrl: url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  currentUrl: url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  nextUrl: CHECK_YOUR_ANSWERS_URL,
+  pageType: AddressPageType.confirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  data: {
+    ...personWithSignificantControlCorrespondenceAddressCacheKeys,
+    enterManualAddressPageType:
+      AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress
+  }
+};
+
 const personWithSignificantControlRouting = [
   registrationAddressRoutingTerritoryChoicePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
   registrationAddressRoutingPostcodePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress,
@@ -227,7 +296,13 @@ const personWithSignificantControlRouting = [
   registrationAddressRoutingPostcodePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
   registrationAddressRoutingChoosePersonWithSignificantControlIndividualPersonUsualResidentialAddress,
   registrationAddressRoutingEnterPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
-  registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress
+  registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPersonUsualResidentialAddress,
+
+  registrationAddressRoutingTerritoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  registrationAddressRoutingPostcodePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  registrationAddressRoutingChoosePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  registrationAddressRoutingEnterPersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+  registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress
 ];
 
 export default personWithSignificantControlRouting;

--- a/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
+++ b/src/presentation/test/builder/PersonWithSignificantControlBuilder.ts
@@ -103,6 +103,11 @@ class PersonWithSignificantControlBuilder {
     return this;
   }
 
+  withServiceAddress(address: Record<string, any>) {
+    this.data.service_address = address;
+    return this;
+  }
+
   isIndividualPerson() {
     this.data = {
       ...this.data,

--- a/src/presentation/test/integration/postTransition/generalPartner/address/enter-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/enter-general-partner-correspondence-address.test.ts
@@ -77,6 +77,7 @@ describe("Enter Correspondence Address Page", () => {
           "usualResidentialAddress",
           "principalOfficeAddress",
           "limitedPartner",
+          "personWithSignificantControl",
           "postcodeOptional",
           "errorMessages",
           // uk countries
@@ -122,6 +123,7 @@ describe("Enter Correspondence Address Page", () => {
           "usualResidentialAddress",
           "limitedPartner",
           "principalOfficeAddress",
+          "personWithSignificantControl",
           "errorMessages",
           // uk countries
           "countryEngland",

--- a/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -64,6 +64,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).not.toContain("WELSH -");
@@ -102,6 +103,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).toContain("WELSH -");

--- a/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/enter-general-partner-correspondence-address.test.ts
@@ -67,6 +67,7 @@ describe("Enter Correspondence Address Page", () => {
         "usualResidentialAddress",
         "principalOfficeAddress",
         "limitedPartner",
+        "personWithSignificantControl",
         "postcodeOptional",
         "errorMessages",
         // uk countries
@@ -102,6 +103,7 @@ describe("Enter Correspondence Address Page", () => {
         "usualResidentialAddress",
         "limitedPartner",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages",
         // uk countries
         "countryEngland",

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -55,6 +55,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).not.toContain("WELSH -");
@@ -86,6 +87,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).toContain("WELSH -");

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-correspondence-address.test.ts
@@ -1,0 +1,169 @@
+import request from "supertest";
+
+import enGeneralTranslationText from "../../../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../../../locales/cy/translations.json";
+import enAddressTranslationText from "../../../../../../../locales/en/address.json";
+import cyAddressTranslationText from "../../../../../../../locales/cy/address.json";
+import enErrorsTranslationText from "../../../../../../../locales/en/errors.json";
+
+import app from "../../../app";
+import { appDevDependencies } from "config/dev-dependencies";
+import { getUrl, setLocalesEnabled, testTranslations, countOccurrences } from "../../../../utils";
+import * as config from "../../../../../../config";
+
+import {
+  CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+} from "presentation/controller/addressLookUp/url/registration";
+
+import AddressPageType from "presentation/controller/addressLookUp/PageType";
+import { englandAddressList } from "../../../../../../infrastructure/gateway/addressLookUp/AddressLookUpInMemoryGateway";
+import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
+import TransactionPersonWithSignificantControl from "../../../../../../domain/entities/TransactionPersonWithSignificantControl";
+
+describe("Choose correspondence address individual person page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText };
+  const URL = getUrl(CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+  const REDIRECT_URL = getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+
+  let personWithSignificantControl: TransactionPersonWithSignificantControl;
+
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    personWithSignificantControl = new PersonWithSignificantControlBuilder()
+      .isIndividualPerson()
+      .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+      .build();
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+    appDevDependencies.addressLookUpGateway.setError(false);
+    appDevDependencies.cacheRepository.feedCache({
+      [appDevDependencies.transactionGateway.transactionId]: {
+        ["service_address"]: {
+          postal_code: "ST6 3LJ",
+          premises: "",
+          address_line_1: "",
+          address_line_2: "",
+          locality: "",
+          country: ""
+        }
+      }
+    });
+
+    appDevDependencies.addressLookUpGateway.feedEnglandAddresses(englandAddressList);
+  });
+
+  describe("GET choose correspondence address individual person", () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])(
+      "should load the choose correspondence address individual person page with %s text",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        setLocalesEnabled(true);
+
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+        testTranslations(
+          res.text,
+          translationText.address.chooseAddress.personWithSignificantControlCorrespondenceAddress
+        );
+
+        expect(res.text).toContain(
+          personWithSignificantControl?.data?.forename?.toUpperCase()
+          + " " + personWithSignificantControl?.data?.middle_names?.toUpperCase()
+          + " " + personWithSignificantControl?.data?.surname?.toUpperCase()
+        );
+      }
+    );
+
+    it("should populate the address list for %s", async () => {
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("2 Duncalf Street, Stoke-On-Trent, ST6 3LJ");
+      expect(res.text).toContain("The Lodge Duncalf&#39;s Street, Castle Hill, Stoke-On-Trent, ST6 3LJ");
+      expect(res.text).toContain("4 Duncalf Street, Stoke-On-Trent, ST6 3LJ");
+      expect(res.text).toContain("6 Duncalf Street, Stoke-On-Trent, ST6 3LJ");
+    });
+
+    it("should redirect to the confirm page if the list contains only one element - %s", async () => {
+      // set the gateway to return only one address for the postcode
+      appDevDependencies.addressLookUpGateway.feedEnglandAddresses([englandAddressList[0]]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    }
+    );
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])(
+      "should return %s error page when gateway getListOfValidPostcodeAddresses throws an error",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        appDevDependencies.addressLookUpGateway.setError(true);
+
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(500);
+        expect(res.text).toContain(translationText.errorPage.title);
+      }
+    );
+  });
+
+  describe("POST choose correspondence address individual person page", () => {
+    it("should redirect to the next page and add select address to cache for %s", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType: AddressPageType.choosePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+          selected_address: `{
+              "postal_code": "ST6 3LJ",
+              "premises": "4",
+              "address_line_1": "DUNCALF STREET",
+              "address_line_2": "",
+              "locality": "STOKE-ON-TRENT",
+              "country": "GB-ENG"
+            }`
+        });
+
+      expect(res.status).toBe(302);
+
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+
+      expect(appDevDependencies.cacheRepository.cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
+        [appDevDependencies.transactionGateway.transactionId]: {
+          service_address: {
+            postal_code: "ST6 3LJ",
+            premises: "4",
+            address_line_1: "DUNCALF STREET",
+            address_line_2: "",
+            locality: "STOKE-ON-TRENT",
+            country: "GB-ENG"
+          }
+        }
+      });
+    }
+    );
+    it("should trigger GDS validation error when no address is selected for %s", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType: AddressPageType.choosePersonWithSignificantControlIndividualPersonCorrespondenceAddress,
+        });
+
+      const errorMessage = enErrorsTranslationText.errorMessages.address.chooseAddress.selectionRequired;
+
+      expect(res.status).toBe(200);
+      expect(countOccurrences(res.text, errorMessage)).toBe(2);
+    }
+    );
+  });
+});

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-correspondence-address.test.ts
@@ -1,0 +1,196 @@
+import request from "supertest";
+
+import enGeneralTranslationText from "../../../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../../../locales/cy/translations.json";
+import enAddressTranslationText from "../../../../../../../locales/en/address.json";
+import cyAddressTranslationText from "../../../../../../../locales/cy/address.json";
+import enErrorMessages from "../../../../../../../locales/en/errors.json";
+import cyErrorMessages from "../../../../../../../locales/cy/errors.json";
+
+import app from "../../../app";
+import { getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { appDevDependencies } from "../../../../../../config/dev-dependencies";
+
+import {
+  CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+} from "../../../../../controller/addressLookUp/url/registration";
+
+import AddressPageType from "../../../../../controller/addressLookUp/PageType";
+import TransactionPersonWithSignificantControl from "../../../../../../domain/entities/TransactionPersonWithSignificantControl";
+import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
+import { CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/registration/url";
+
+describe("Confirm PSC correspondence Address Page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorMessages };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorMessages };
+
+  const URL = getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+  const REDIRECT_URL = getUrl(CHECK_YOUR_ANSWERS_URL);
+  const MANUAL_ENTRY_URL = getUrl(ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+
+  const pageType = AddressPageType.confirmPersonWithSignificantControlIndividualPersonCorrespondenceAddress;
+
+  let personWithSignificantControl: TransactionPersonWithSignificantControl;
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    personWithSignificantControl = new PersonWithSignificantControlBuilder()
+      .isIndividualPerson()
+      .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+      .build();
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+    appDevDependencies.cacheRepository.feedCache({
+      [appDevDependencies.transactionGateway.transactionId]: {
+        service_address: {
+          postal_code: "ST6 3LJ",
+          premises: "4",
+          address_line_1: "line 1",
+          address_line_2: "line 2",
+          locality: "stoke-on-trent",
+          region: "region",
+          country: "England"
+        }
+      }
+    });
+  });
+
+  describe("GET Confirm PSC correspondence Address Page", () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])(
+      "should load the confirm PSC correspondence address page with %s text",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+        testTranslations(res.text, translationText.address.confirm.personWithSignificantControlCorrespondenceAddress);
+
+        expect(res.text).toContain("4 Line 1");
+        expect(res.text).toContain("Line 2");
+        expect(res.text).toContain("Stoke-On-Trent");
+        expect(res.text).toContain("Region");
+        expect(res.text).toContain("ST6 3LJ");
+
+        expect(res.text).toContain(
+          [
+            personWithSignificantControl?.data?.forename,
+            personWithSignificantControl?.data?.middle_names,
+            personWithSignificantControl?.data?.surname
+          ].join(' ').toUpperCase()
+        );
+      }
+    );
+
+    it.each([
+      [
+        "overseas",
+        getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL)
+      ],
+      [
+        "unitedKingdom",
+        getUrl(POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL)
+      ]
+    ])("should have the correct back link for territory for %s", async (territory: string, backLink: string) => {
+      appDevDependencies.cacheRepository.feedCache({
+        [appDevDependencies.transactionGateway.transactionId]: {
+          ura_territory_choice: territory
+        }
+      });
+
+      const res = await request(app).get(URL);
+
+      expect(res.text).toContain(backLink);
+    }
+    );
+
+    it("should redirect to manual address page if address is incomplete", async () => {
+      appDevDependencies.cacheRepository.feedCache({
+        [appDevDependencies.transactionGateway.transactionId]: {
+          service_address: {
+            postal_code: "ST6 3LJ",
+            premises: "4",
+            address_line_1: "line 1",
+            address_line_2: "line 2",
+            locality: "stoke-on-trent",
+            region: "region",
+            country: null
+          }
+        }
+      });
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${MANUAL_ENTRY_URL}`);
+    }
+    );
+  });
+
+  describe("POST Confirm PSC correspondence Address Page", () => {
+    it("should redirect to the next page", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType,
+          address: `{
+            "postal_code": "ST6 3LJ",
+            "premises": "4",
+            "address_line_1": "DUNCALF STREET",
+            "address_line_2": "",
+            "locality": "STOKE-ON-TRENT",
+            "country": "England"
+          }`
+        });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
+
+    it("should show error message if address is not provided", async () => {
+      appDevDependencies.cacheRepository.feedCache({});
+
+      const res = await request(app).post(URL).send({
+        pageType
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("You must provide an address");
+    }
+    );
+
+    it.each([
+      [
+        "en",
+        enTranslationText
+      ],
+      [
+        "cy",
+        cyTranslationText
+      ]
+    ])(
+      "should show validation error message if country is missing with lang %s",
+      async (lang: string, translationText: Record<string, any>) => {
+        setLocalesEnabled(true);
+        const res = await request(app).post(`${URL}?lang=${lang}`).send({
+          pageType,
+          address: `{
+            "postal_code": "ST6 3LJ",
+            "premises": "4",
+            "address_line_1": "DUNCALF STREET",
+            "address_line_2": "",
+            "locality": "STOKE-ON-TRENT",
+            "country": ""
+          }`
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(translationText.errorMessages.address.confirm.countryMissing);
+      }
+    );
+  });
+});

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/confirm-psc-usual-residential-address.test.ts
@@ -12,6 +12,7 @@ import { getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 
 import {
+  CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
   CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
   ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
   POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
@@ -149,6 +150,43 @@ describe("Confirm PSC usual residential Address Page", () => {
 
       expect(res.status).toBe(302);
       expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    });
+
+    it("should redirect to the confirm PSC correspondence address page if service address has already been stored in API data", async () => {
+      personWithSignificantControl = new PersonWithSignificantControlBuilder()
+        .isIndividualPerson()
+        .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+        .withServiceAddress({
+          postal_code: "ST6 3LJ",
+          premises: "4",
+          address_line_1: "line 1",
+          address_line_2: "line 2",
+          locality: "stoke-on-trent",
+          region: "region",
+          country: "England"
+        })
+        .build();
+
+      appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType,
+          address: `{
+            "postal_code": "ST6 3LJ",
+            "premises": "4",
+            "address_line_1": "DUNCALF STREET",
+            "address_line_2": "",
+            "locality": "STOKE-ON-TRENT",
+            "country": "England"
+          }`
+        });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(
+        getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL)
+      );
     });
 
     it("should show error message if address is not provided", async () => {

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/enter-psc-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/enter-psc-correspondence-address.test.ts
@@ -1,0 +1,261 @@
+import request from "supertest";
+import { Jurisdiction } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+
+import enGeneralTranslationText from "../../../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../../../locales/cy/translations.json";
+import enAddressTranslationText from "../../../../../../../locales/en/address.json";
+import cyAddressTranslationText from "../../../../../../../locales/cy/address.json";
+import enErrorsTranslationText from "../../../../../../../locales/en/errors.json";
+import cyErrorsTranslationText from "../../../../../../../locales/cy/errors.json";
+
+import app from "../../../app";
+import { appDevDependencies } from "../../../../../../config/dev-dependencies";
+import {
+  countOccurrences,
+  getUrl,
+  setLocalesEnabled,
+  testTranslations
+} from "../../../../utils";
+
+import {
+  CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL
+} from "presentation/controller/addressLookUp/url/registration";
+
+import AddressPageType from "../../../../../controller/addressLookUp/PageType";
+import LimitedPartnershipBuilder from "../../../../builder/LimitedPartnershipBuilder";
+import TransactionPersonWithSignificantControl from "../../../../../../domain/entities/TransactionPersonWithSignificantControl";
+import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
+
+describe("Enter person with significant control's correspondence address manual address page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorsTranslationText };
+
+  const URL = getUrl(ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+  const REDIRECT_URL = getUrl(CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+
+  const pageType = AddressPageType.enterPersonWithSignificantControlIndividualPersonCorrespondenceAddress;
+
+  let personWithSignificantControl: TransactionPersonWithSignificantControl;
+
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    personWithSignificantControl = new PersonWithSignificantControlBuilder()
+      .isIndividualPerson()
+      .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+      .build();
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+    const limitedPartnership = new LimitedPartnershipBuilder()
+      .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
+      .withJurisdiction(Jurisdiction.SCOTLAND)
+      .build();
+    appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+    appDevDependencies.cacheRepository.feedCache(null);
+  });
+
+  describe("Get enter person with significant control's correspondence address page", () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])(
+      "should load enter person with significant controls correspondence address page with %s",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+
+        testTranslations(res.text, translationText.address.enterAddress, [
+          "registeredOfficeAddress",
+          "principalPlaceOfBusinessAddress",
+          "jurisdictionCountry",
+          "postcodeMissing",
+          "usualResidentialAddress",
+          "generalPartner",
+          "limitedPartner",
+          "principalOfficeAddress",
+          "errorMessages"
+        ]);
+
+        expect(res.text).toContain(
+          [
+            personWithSignificantControl?.data?.forename,
+            personWithSignificantControl?.data?.middle_names,
+            personWithSignificantControl?.data?.surname
+          ].join(' ').toUpperCase()
+        );
+      }
+    );
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])(
+      "should load enter person with significant controls correspondence address page with %s errors",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        const errorMessages = translationText.errorMessages.address.enterAddress;
+
+        appDevDependencies.cacheRepository.feedCache({
+          [appDevDependencies.transactionGateway.transactionId]: {
+            service_address: {
+              postal_code: "ST6 3LJ",
+              premises: "4",
+              address_line_1: null,
+              address_line_2: "line 2",
+              locality: "stoke-on-trent",
+              region: "region",
+              country: null
+            }
+          }
+        });
+
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+
+        expect(res.text).toContain(errorMessages.addressLine1Missing);
+        expect(countOccurrences(res.text, errorMessages.addressLine1Missing)).toBe(2);
+
+        expect(res.text).toContain(errorMessages.countryMissing);
+        expect(countOccurrences(res.text, errorMessages.countryMissing)).toBe(3);
+
+        expect(res.text).toContain(
+          [
+            personWithSignificantControl?.data?.forename,
+            personWithSignificantControl?.data?.middle_names,
+            personWithSignificantControl?.data?.surname
+          ].join(' ').toUpperCase()
+        );
+      }
+    );
+  });
+
+  describe("Post enter person with significant control's correspondence address page", () => {
+    it("should not return a validation error when an overseas address and postcode does not conform to UK format", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType,
+          ...personWithSignificantControl.data?.usual_residential_address,
+          postal_code: "GG1 1GG",
+          country: "City"
+        });
+
+      expect(res.status).toBe(302);
+
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    }
+    );
+
+    it("should return a validation error when a UK address and postcode format is invalid", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType,
+          ...personWithSignificantControl.data?.usual_residential_address,
+          postal_code: "here"
+        });
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain(enTranslationText.errorMessages.address.enterAddress.postcodeFormat);
+      expect(res.text).toContain(enTranslationText.govUk.error.title);
+
+      expect(res.text).toContain(
+        [
+          personWithSignificantControl?.data?.forename,
+          personWithSignificantControl?.data?.middle_names,
+          personWithSignificantControl?.data?.surname
+        ].join(' ').toUpperCase()
+      );
+    }
+    );
+
+    it("should not return validation errors when address fields contain valid but non alpha-numeric characters", async () => {
+      const res = await request(app)
+        .post(URL)
+        .send({
+          pageType,
+          ...personWithSignificantControl.data?.usual_residential_address,
+          premises: "-,.:; &@$£¥€'?!/\\řśŝşšţťŧùúûüũūŭůűųŵẁẃẅỳýŷÿźżžñńņňŋòóôõöøōŏőǿœŕŗàáâãäåāăąæǽçćĉċč",
+          address_line_1: "()[]{}<>*=#%+ÀÁÂÃÄÅĀĂĄÆǼÇĆĈĊČÞĎÐÈÉÊËĒĔĖĘĚĜĞĠĢ",
+          address_line_2: "ĤĦÌÍÎÏĨĪĬĮİĴĶĹĻĽĿŁÑŃŅŇŊÒÓÔÕÖØŌŎŐǾŒŔŖŘŚŜŞŠŢŤŦ",
+          locality: "ÙÚÛÜŨŪŬŮŰŲŴẀẂẄỲÝŶŸŹŻŽa-zÀÖØſƒǺẀỲ",
+          region: "þďðèéêëēĕėęěĝģğġĥħìíîïĩīĭįĵķĺļľŀł"
+        });
+
+      expect(res.status).toBe(302);
+
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    }
+    );
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])("should return %s validation errors when address fields contain invalid characters", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app)
+        .post(URL + `?lang=${lang}`)
+        .send({
+          pageType,
+          ...personWithSignificantControl.data?.usual_residential_address,
+          premises: "±",
+          address_line_1: "±",
+          address_line_2: "±",
+          locality: "±",
+          region: "±"
+        });
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.premisesInvalid);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.addressLine1Invalid);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.addressLine2Invalid);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.localityInvalid);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.regionInvalid);
+      expect(res.text).toContain(translationText.govUk.error.title);
+      expect(res.text).toContain(
+        [
+          personWithSignificantControl?.data?.forename,
+          personWithSignificantControl?.data?.middle_names,
+          personWithSignificantControl?.data?.surname
+        ].join(' ').toUpperCase()
+      );
+    }
+    );
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText],
+    ])("should return %s validation errors when address fields exceed character limit", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app)
+        .post(URL + `?lang=${lang}`)
+        .send({
+          pageType,
+          ...personWithSignificantControl.data?.usual_residential_address,
+          premises: "toomanycharacters".repeat(13),
+          address_line_1: "toomanycharacters".repeat(4),
+          address_line_2: "toomanycharacters".repeat(4),
+          locality: "toomanycharacters".repeat(4),
+          region: "toomanycharacters".repeat(4)
+        });
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.premisesLength);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.addressLine1Length);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.addressLine2Length);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.localityLength);
+      expect(res.text).toContain(translationText.errorMessages.address.enterAddress.regionLength);
+      expect(res.text).toContain(
+        [
+          personWithSignificantControl?.data?.forename,
+          personWithSignificantControl?.data?.middle_names,
+          personWithSignificantControl?.data?.surname
+        ].join(' ').toUpperCase()
+      );
+    }
+    );
+  });
+});

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-correspondence-address.test.ts
@@ -1,0 +1,156 @@
+import request from "supertest";
+import { Jurisdiction } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+
+import enGeneralTranslationText from "../../../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../../../locales/cy/translations.json";
+import enAddressTranslationText from "../../../../../../../locales/en/address.json";
+import cyAddressTranslationText from "../../../../../../../locales/cy/address.json";
+import enErrorsTranslationText from "../../../../../../../locales/en/errors.json";
+import cyErrorsTranslationText from "../../../../../../../locales/cy/errors.json";
+
+import app from "../../../app";
+import { appDevDependencies } from "../../../../../../config/dev-dependencies";
+import {
+  getUrl,
+  setLocalesEnabled,
+  toEscapedHtml,
+  testTranslations
+} from "../../../../utils";
+
+import {
+  CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL
+} from "presentation/controller/addressLookUp/url/registration";
+
+import AddressPageType from "../../../../../controller/addressLookUp/PageType";
+import { APPLICATION_CACHE_KEY } from "../../../../../../config/constants";
+
+import LimitedPartnershipBuilder from "../../../../builder/LimitedPartnershipBuilder";
+import TransactionPersonWithSignificantControl from "../../../../../../domain/entities/TransactionPersonWithSignificantControl";
+import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
+
+describe("Postcode individual person correspondence address page", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorsTranslationText };
+
+  const URL = getUrl(POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+  const REDIRECT_URL = getUrl(CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+
+  const pageType = AddressPageType.postcodePersonWithSignificantControlIndividualPersonCorrespondenceAddress;
+
+  let personWithSignificantControl: TransactionPersonWithSignificantControl;
+
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    personWithSignificantControl = new PersonWithSignificantControlBuilder()
+      .isIndividualPerson()
+      .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+      .build();
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+    const limitedPartnership = new LimitedPartnershipBuilder()
+      .withId(appDevDependencies.limitedPartnershipGateway.submissionId)
+      .withJurisdiction(Jurisdiction.SCOTLAND)
+      .build();
+    appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+  });
+
+  describe("Get postcode individual person correspondence address page", () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])(
+      "should load the correspondence address page with %s text",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        const res = await request(app).get(URL + `?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+
+        expect(res.text).toContain(
+          toEscapedHtml(
+            translationText.address.findPostcode.personWithSignificantControl.correspondenceAddress
+              .whatIsCorrespondenceAddress
+          ) + ` - ${translationText.serviceRegistration} - GOV.UK`
+        );
+
+        testTranslations(res.text, translationText.address.findPostcode, [
+          "registeredOfficeAddress",
+          "principalPlaceOfBusiness",
+          "principalOfficeAddress",
+          "usualResidentialAddress",
+          "errorMessages",
+          "limitedPartner",
+          "generalPartner"
+        ]);
+
+        expect(res.text).toContain(
+          [
+            personWithSignificantControl?.data?.forename,
+            personWithSignificantControl?.data?.middle_names,
+            personWithSignificantControl?.data?.surname
+          ].join(' ').toUpperCase()
+        );
+      }
+    );
+  });
+
+  describe("Post postcode individual person correspondence address page", () => {
+    it("should validate the post code then redirect to the next page", async () => {
+      const res = await request(app).post(URL).send({
+        pageType,
+        premises: null,
+        postal_code: appDevDependencies.addressLookUpGateway.englandAddresses[0].postcode
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+
+      expect(appDevDependencies.cacheRepository.cache).toEqual({
+        [APPLICATION_CACHE_KEY]: {
+          [appDevDependencies.transactionGateway.transactionId]: {
+            ["service_address"]: {
+              postal_code: "ST6 3LJ",
+              address_line_1: "",
+              address_line_2: "",
+              locality: "",
+              country: "",
+              premises: ""
+            }
+          }
+        }
+      });
+    }
+    );
+
+    it("should validate the post code then redirect to the next page even if LP jurisdiction is not in the same locality", async () => {
+      const res = await request(app).post(URL).send({
+        pageType,
+        premises: null,
+        postal_code: appDevDependencies.addressLookUpGateway.englandAddresses[0].postcode
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+    }
+    );
+
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])("should return an %s error if the postcode is not valid", async (_description: string, lang: string, translationText: Record<string, any>) => {
+      const res = await request(app).post(URL + `?lang=${lang}`).send({
+        pageType,
+        premises: null,
+        postal_code: "AA1 1AA"
+      });
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain(translationText.errorMessages.address.postcodeLookup.postcodeNotFound);
+      expect(res.text).toContain(personWithSignificantControl?.data?.legal_entity_name?.toUpperCase());
+    }
+    );
+  });
+});

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/territory-choice-psc-correspondence-address.test.ts
@@ -1,0 +1,137 @@
+import request from "supertest";
+
+import enGeneralTranslationText from "../../../../../../../locales/en/translations.json";
+import cyGeneralTranslationText from "../../../../../../../locales/cy/translations.json";
+import enAddressTranslationText from "../../../../../../../locales/en/address.json";
+import cyAddressTranslationText from "../../../../../../../locales/cy/address.json";
+import enErrorsTranslationText from "../../../../../../../locales/en/errors.json";
+import cyErrorsTranslationText from "../../../../../../../locales/cy/errors.json";
+
+import app from "../../../app";
+import { appDevDependencies } from "../../../../../../config/dev-dependencies";
+import { countOccurrences, getUrl, setLocalesEnabled, testTranslations, toEscapedHtml } from "../../../../utils";
+import { APPLICATION_CACHE_KEY } from "../../../../../../config/constants";
+
+import {
+  TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+  ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL
+} from "../../../../../controller/addressLookUp/url/registration";
+
+import AddressPageType from "../../../../../controller/addressLookUp/PageType";
+import LimitedPartnershipBuilder from "../../../../builder/LimitedPartnershipBuilder";
+import PersonWithSignificantControlBuilder from "../../../../builder/PersonWithSignificantControlBuilder";
+
+import TransactionPersonWithSignificantControl from "../../../../../../domain/entities/TransactionPersonWithSignificantControl";
+
+describe("PSC correspondence Address Territory Choice", () => {
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorsTranslationText };
+
+  const URL = getUrl(TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL);
+
+  const pageType = AddressPageType.territoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress;
+
+  let personWithSignificantControl: TransactionPersonWithSignificantControl;
+
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    personWithSignificantControl = new PersonWithSignificantControlBuilder()
+      .isIndividualPerson()
+      .withId(appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId)
+      .build();
+
+    appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+    const limitedPartnership = new LimitedPartnershipBuilder().build();
+    appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+  });
+
+  describe("GET PSC correspondence address territory choice", () => {
+    it.each([
+      ["English", "en", enTranslationText],
+      ["Welsh", "cy", cyTranslationText]
+    ])(
+      "should load the PSC correspondence address territory choice page with %s text",
+      async (_description: string, lang: string, translationText: Record<string, any>) => {
+        const res = await request(app).get(`${URL}?lang=${lang}`);
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(
+          toEscapedHtml(
+            `${translationText.address.territoryChoice.personWithSignificantControlCorrespondenceAddress.title} - ${translationText.serviceRegistration} - GOV.UK`
+          )
+        );
+
+        testTranslations(
+          res.text,
+          translationText.address.territoryChoice.personWithSignificantControlCorrespondenceAddress
+        );
+        testTranslations(res.text, translationText.address.territories);
+
+        expect(res.text).toContain(
+          [
+            personWithSignificantControl?.data?.forename,
+            personWithSignificantControl?.data?.middle_names,
+            personWithSignificantControl?.data?.surname
+          ].join(' ').toUpperCase()
+        );
+      }
+    );
+  });
+
+  describe("POST PSC territory choice", () => {
+    it.each([
+      [
+        "United Kingdom",
+        "unitedKingdom",
+        getUrl(POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL)
+      ],
+      [
+        "Overseas",
+        "overseas",
+        getUrl(ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL)
+      ]
+    ])(
+      "should redirect to postcode lookup page when United Kingdom is selected",
+      async (_description: string, territory: string, expectedRedirectUrl: string) => {
+        const res = await request(app).post(URL).send({
+          pageType,
+          parameter: territory
+        });
+
+        expect(res.status).toBe(302);
+        expect(res.text).toContain(expectedRedirectUrl);
+
+        expect(appDevDependencies.cacheRepository.cache).toEqual({
+          [APPLICATION_CACHE_KEY]: {
+            [appDevDependencies.transactionGateway.transactionId]: {
+              ["sa_territory_choice"]: territory
+            }
+          }
+        });
+      }
+    );
+
+    it("should show an error message when no selection is made for territory choice", async () => {
+      const res = await request(app).post(URL).send({
+        pageType
+      });
+
+      const errorMessages = enTranslationText.errorMessages.address.territoryChoice;
+      const errorMessage = `${errorMessages.noOptionSelectedStart}service address${errorMessages.noOptionSelectedEnd}`;
+
+      expect(res.status).toBe(200);
+      expect(countOccurrences(res.text, errorMessage)).toBe(2);
+      expect(res.text).toContain(
+        [
+          personWithSignificantControl?.data?.forename,
+          personWithSignificantControl?.data?.middle_names,
+          personWithSignificantControl?.data?.surname
+        ].join(' ').toUpperCase()
+      );
+    });
+  });
+});
+

--- a/src/presentation/test/integration/transition/generalPartner/address/enter-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/enter-general-partner-correspondence-address.test.ts
@@ -64,6 +64,7 @@ describe("Enter Correspondence Address Page", () => {
         "usualResidentialAddress",
         "principalOfficeAddress",
         "limitedPartner",
+        "personWithSignificantControl",
         "postcodeOptional",
         "errorMessages",
         // uk countries
@@ -99,6 +100,7 @@ describe("Enter Correspondence Address Page", () => {
         "usualResidentialAddress",
         "limitedPartner",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages",
         // uk countries
         "countryEngland",

--- a/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -56,6 +56,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).not.toContain("WELSH -");
@@ -87,6 +88,7 @@ describe("Postcode general partner's correspondence address page", () => {
         "principalPlaceOfBusiness",
         "usualResidentialAddress",
         "principalOfficeAddress",
+        "personWithSignificantControl",
         "errorMessages"
       ]);
       expect(res.text).toContain("WELSH -");

--- a/src/routes/addressRegistration.ts
+++ b/src/routes/addressRegistration.ts
@@ -456,6 +456,53 @@ export const addressLookUpEndpoints = (router: Router, dependencies: IDependenci
     url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_USUAL_RESIDENTIAL_ADDRESS_URL,
     dependencies.addressLookUpController.confirmAddress()
   );
+
+  // correspondence address - Individual Person
+
+  router.get(
+    url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.getPageRouting()
+  );
+  router.post(
+    url.TERRITORY_CHOICE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.handleTerritoryChoice()
+  );
+
+  router.get(
+    url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.getPageRouting()
+  );
+  router.post(
+    url.POSTCODE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.postcodeValidation()
+  );
+
+  router.get(
+    url.CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.getPageRouting()
+  );
+  router.post(
+    url.CHOOSE_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.selectAddress()
+  );
+
+  router.get(
+    url.ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.getPageRouting()
+  );
+  router.post(
+    url.ENTER_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.sendManualAddress()
+  );
+
+  router.get(
+    url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.getPageRouting()
+  );
+  router.post(
+    url.CONFIRM_PERSON_WITH_SIGNIFICANT_CONTROL_INDIVIDUAL_PERSON_CORRESPONDENCE_ADDRESS_URL,
+    dependencies.addressLookUpController.confirmAddress()
+  );
 };
 
 export default addressLookUpEndpoints;

--- a/src/views/choose-person-with-significant-control-individual-person-correspondence-address.njk
+++ b/src/views/choose-person-with-significant-control-individual-person-correspondence-address.njk
@@ -1,0 +1,20 @@
+{% extends "layout.njk" %}
+
+{% set pageTitle = i18n.address.chooseAddress.personWithSignificantControlCorrespondenceAddress.title %}
+{% set pageTitleHint = i18n.address.chooseAddress.personWithSignificantControlCorrespondenceAddress.titleHint %}
+{% set publicRegisterInformationLine1 = i18n.address.chooseAddress.personWithSignificantControlCorrespondenceAddress.publicRegisterInformationLine1 %}
+
+{% set cache = props.data.cache['service_address'] %}
+{% set addressLink = i18n.address.chooseAddress.addressLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
+
+      {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
+           
+      {% include "pages/address/choose-address-form.njk" %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/views/confirm-person-with-significant-control-individual-person-correspondence-address.njk
+++ b/src/views/confirm-person-with-significant-control-individual-person-correspondence-address.njk
@@ -1,0 +1,33 @@
+{% extends "layout.njk" %}
+
+{% set pageTitle = i18n.address.confirm.personWithSignificantControlCorrespondenceAddress.title %}
+{% set publicRegisterInformationLine1 = i18n.address.confirm.personWithSignificantControlCorrespondenceAddress.publicRegisterLine1 %}
+{% set cacheKey = props.data.addressCacheKey %}
+{% set data = props.data.personWithSignificantControl.data.service_address %}
+
+{% block backLink %}
+  {% set hrefValue = props.previousUrl %}
+
+  {% if props.data.cache.sa_territory_choice == "overseas" %}
+     {% set hrefValue = props.currentUrl | replace(props.pageType, props.data.enterManualAddressPageType) %}
+  {% endif %}
+
+  {{ govukBackLink({
+    text: i18n.links.back,
+    attributes: {
+      "data-event-id": "back-link"
+    },
+    href: hrefValue
+  }) }}
+{% endblock %}
+
+{% block content %}
+ <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
+      {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
+
+      {% include "pages/address/confirm-address-form.njk" %}
+    </div>
+  </div> 
+{% endblock %}

--- a/src/views/enter-person-with-significant-control-individual-person-correspondence-address.njk
+++ b/src/views/enter-person-with-significant-control-individual-person-correspondence-address.njk
@@ -1,0 +1,96 @@
+{% extends "layout.njk" %}
+{% import 'includes/countries.njk' as macros %}
+
+{% set correspondenceAddressKey = "service_address" %}
+
+{% block backLink %}
+  {% set hrefValue = props.previousUrl %}
+
+  {% if props.data.cache.sa_territory_choice == "overseas" %}
+    {% set hrefValue = props.currentUrl | replace(props.pageType, props.data.territoryPageType) %}
+  {% endif %}
+
+  {{ govukBackLink({
+    text: i18n.links.back,
+    attributes: {
+      "data-event-id": "back-link"
+    },
+    href: hrefValue
+  }) }}
+{% endblock %}
+
+{% if props.data.address %}
+  {% set address = props.data.address %}
+{% elif props.data.cache[correspondenceAddressKey] %}
+  {% set address = props.data.cache[correspondenceAddressKey] %}
+{% elif props.data.personWithSignificantControl.data.service_address %}
+  {% set address = props.data.personWithSignificantControl.data.service_address %}
+{% elif props.data.chsCorrespondenceAddress %}
+  {% set address = props.data.chsCorrespondenceAddress %}
+{% else %}
+  {% set address = {} %}
+{% endif %}
+
+{% set pageTitle = i18n.address.enterAddress.personWithSignificantControl.correspondenceAddress.title %}
+{% set titleHint1 = i18n.address.enterAddress.personWithSignificantControl.correspondenceAddress.titleHint %}
+{% set publicRegisterInformationLine1 = i18n.address.enterAddress.personWithSignificantControl.correspondenceAddress.publicInformationLine1 %}
+
+{% set showOverseasList = "true" %}
+{% if props.data.cache.sa_territory_choice %}
+  {% set showOverseasList = props.data.cache.sa_territory_choice  == "overseas" %}
+{% endif %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
+      {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <h1 class="govuk-heading-xl">
+            {{ pageTitle }}
+            </h1>
+        </legend>
+
+        <p class="govuk-hint">{{ titleHint1 }}</p>
+      </fieldset>
+      
+      <form class="form" method="post">
+        <input type="hidden" name="pageType" value={{ props.pageType }}>
+
+        {% include "includes/csrf_token.njk" %}
+        
+        {% if showOverseasList %}
+          {% include "pages/address/enter-address-fields.njk" %}
+
+          {{ govukInput({
+            label: {
+              text: i18n.address.enterAddress.personWithSignificantControl.correspondenceAddress.postcodeOptional
+            },
+            errorMessage: props.errors.postal_code if props.errors,
+            classes: "govuk-input--width-10",
+            id: "postal_code",
+            name: "postal_code",
+            value: address.postal_code
+          }) }}
+
+          {% set countryFormId = "country" %}
+          {% set countryText = i18n.address.enterAddress.country %}
+          {% set countryFormValue = address.country %}
+          {% set countryErrorMessage = props.errors.country if props.errors %}
+          {% set labelFormatting = "govuk-label govuk-input--width-10" %}
+
+          {{ macros.getSpecifiedCountryList(i18n, props.data.cache.sa_territory_choice, countryFormId, countryText, countryFormValue, countryErrorMessage, labelFormatting, false) }}
+
+        {% else %}
+          {% include "pages/address/enter-address-common-fields.njk" %}
+        {% endif %}
+        
+        {% include "includes/public-register-information.njk" %}
+
+        {% include "includes/save-and-continue-button.njk" %}
+      </form>
+    </div>
+  </div> 
+{% endblock %}

--- a/src/views/postcode-person-with-significant-control-individual-person-correspondence-address.njk
+++ b/src/views/postcode-person-with-significant-control-individual-person-correspondence-address.njk
@@ -1,0 +1,26 @@
+{% extends "layout.njk" %}
+
+{% set pageTitle = i18n.address.findPostcode.personWithSignificantControl.correspondenceAddress.whatIsCorrespondenceAddress %}
+{% set titleHint = i18n.address.findPostcode.personWithSignificantControl.correspondenceAddress.titleHint %}
+{% set publicRegisterInformationLine1 = i18n.address.findPostcode.personWithSignificantControl.correspondenceAddress.publicRegisterLine1 %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
+
+      <div>
+        {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
+
+        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+        <p class="govuk-hint">{{ titleHint }}</p>
+      </div>
+
+      {% include "pages/address/postcode-form.njk" %}
+
+    <div>
+      {% include "includes/public-register-information.njk" %}
+    </div>
+   </div>
+
+{% endblock %}

--- a/src/views/uk-or-overseas-person-with-significant-control-individual-person-correspondence-address.njk
+++ b/src/views/uk-or-overseas-person-with-significant-control-individual-person-correspondence-address.njk
@@ -1,0 +1,18 @@
+{% extends "layout.njk" %}
+
+{% set pageTitle = i18n.address.territoryChoice.personWithSignificantControlCorrespondenceAddress.title %}
+{% set titleHint = i18n.address.territoryChoice.personWithSignificantControlCorrespondenceAddress.titleHint %}
+{% set publicRegisterInformationLine1 = i18n.address.territoryChoice.personWithSignificantControlCorrespondenceAddress.publicRegisterInformationLine1 %}
+{% set addressEvent = "person with significant control correspondence address" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "includes/errors.njk" %}
+
+      {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
+
+      {% include "pages/address/territory-address-form.njk" %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1764


### Change description
Add correspondence address 'loop' pages (AKA service address) for individual PSC
Add tests to cover these and check that the confirm URA page redirects to the confirm Correspondence address page if they have already submitted a correspondence address. 


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.