### PR TITLE
LP-1760 Fixes for Date invalid chars and fix wording on individual psc page

### DIFF
--- a/locales/cy/personWithSignificantControl.json
+++ b/locales/cy/personWithSignificantControl.json
@@ -55,7 +55,8 @@
             "addIndividualPerson": {
                 "title": "WELSH - Add a PSC (individual person)",
                 "consent": "WELSH - This person knows their details are being supplied as part of this application",
-                "personTitle": "WELSH - Title",
+                "personTitle": "WELSH - Professional or honorary title (if relevant)",
+                "personTitleHint": "WELSH - For example, Dr or Professor",
                 "personOtherTitle": "WELSH - Other title",
                 "firstName": "WELSH - First name",
                 "middleNames": "WELSH - Middle names",

--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -222,7 +222,8 @@
             "title": "WELSH - People with significant control (PSCs)",
             "headingPscStatement": "WELSH - PSC statement",
             "noPscStatement": "WELSH - There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership.",
-            "changeRemoveOrAdd": "WELSH - Change, remove or add people with significant control (PSCs)"
+            "changeRemoveOrAdd": "WELSH - Change, remove or add people with significant control (PSCs)",
+            "personTitle": "WELSH - Title"
         }
     },
 

--- a/locales/en/personWithSignificantControl.json
+++ b/locales/en/personWithSignificantControl.json
@@ -55,7 +55,8 @@
             "addIndividualPerson": {
                 "title": "Add a PSC (individual person)",
                 "consent": "This person knows their details are being supplied as part of this application",
-                "personTitle": "Title",
+                "personTitle": "Professional or honorary title (if relevant)",
+                "personTitleHint": "For example, Dr or Professor",
                 "personOtherTitle": "Other title",
                 "firstName": "First name",
                 "middleNames": "Middle names",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -222,7 +222,8 @@
             "title": "People with significant control (PSCs)",
             "headingPscStatement": "PSC statement",
             "noPscStatement": "There is no person identified as a person with significant control (either a registrable person or RLE) in relation to the limited partnership.",
-            "changeRemoveOrAdd": "Change, remove or add people with significant control (PSCs)"
+            "changeRemoveOrAdd": "Change, remove or add people with significant control (PSCs)",
+            "personTitle": "Title"
         }
     },
 

--- a/src/domain/validator/DateValidators.ts
+++ b/src/domain/validator/DateValidators.ts
@@ -13,11 +13,25 @@ export type DateErrorMessages = {
   yearInvalidLength: string;
 }
 
+const isDigitsOnly = (value: string): boolean => /^\d+$/.test(value);
+
 const parseDateParts = (day: string, month: string, year: string): { d: number; m: number; y: number } | null => {
+  const trimmedDay = (day || "").trim();
+  const trimmedMonth = (month || "").trim();
+  const trimmedYear = (year || "").trim();
+
+  if (!trimmedDay || !trimmedMonth || !trimmedYear) {
+    return null;
+  }
+
+  if (!isDigitsOnly(trimmedDay) || !isDigitsOnly(trimmedMonth) || !isDigitsOnly(trimmedYear)) {
+    return null;
+  }
+
   // months are 0-indexed in JavaScript Date, so we need to subtract 1 from the month
-  const y = Number(year);
-  const m = Number(month) - 1;
-  const d = Number(day);
+  const y = Number(trimmedYear);
+  const m = Number(trimmedMonth) - 1;
+  const d = Number(trimmedDay);
 
   if ([y, m, d].some(Number.isNaN)) {
     return null;
@@ -156,11 +170,13 @@ export const isDateToday = (day: string, month: string, year: string): boolean =
 };
 
 export const dateContainsInvalidChars = (day: string, month: string, year: string): boolean => {
-  const parsedDay = parseInt(day || "0", 10);
-  const parsedMonth = parseInt(month || "0", 10);
-  const parsedYear = parseInt(year || "0", 10);
+  const trimmedDay = (day || "").trim();
+  const trimmedMonth = (month || "").trim();
+  const trimmedYear = (year || "").trim();
 
-  if (isNaN(parsedDay) || isNaN(parsedMonth) || isNaN(parsedYear)) {
+  if ((trimmedDay && !isDigitsOnly(trimmedDay)) ||
+      (trimmedMonth && !isDigitsOnly(trimmedMonth)) ||
+      (trimmedYear && !isDigitsOnly(trimmedYear))) {
     return true;
   }
 

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -12,6 +12,8 @@ import enGeneralTranslationText from "../../../../../locales/en/translations.jso
 import cyGeneralTranslationText from "../../../../../locales/cy/translations.json";
 import enAddressTranslationText from "../../../../../locales/en/address.json";
 import cyAddressTranslationText from "../../../../../locales/cy/address.json";
+import enPersonWithSignificantControlTranslationText from "../../../../../locales/en/personWithSignificantControl.json";
+import cyPersonWithSignificantControlTranslationText from "../../../../../locales/cy/personWithSignificantControl.json";
 import enErrorMessages from "../../../../../locales/en/errors.json";
 import cyErrorMessages from "../../../../../locales/cy/errors.json";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
@@ -39,8 +41,8 @@ import TransactionGeneralPartner from "../../../../domain/entities/TransactionGe
 import TransactionLimitedPartnership from "../../../../domain/entities/TransactionLimitedPartnership";
 
 describe("Check Your Answers Page", () => {
-  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorMessages };
-  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorMessages };
+  const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorMessages, ...enPersonWithSignificantControlTranslationText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorMessages, ...cyPersonWithSignificantControlTranslationText };
 
   const URL = getUrl(CHECK_YOUR_ANSWERS_URL);
   const PAYMENT_LINK_JOURNEY = "https://api-test-payments.chs.local:4001";
@@ -574,6 +576,8 @@ describe("Check Your Answers Page", () => {
         const res = await request(app).get(URL + `?lang=${lang}`);
 
         expect(res.status).toBe(200);
+        expect(res.text).toContain(translationText.checkYourAnswersPage.psc.personTitle);
+        expect(res.text).not.toContain(translationText.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.personTitle);
         expect(res.text).toContain(psc.data?.title);
         expect(res.text).toContain(psc.data?.forename);
         expect(res.text).toContain(psc.data?.middle_names);

--- a/src/presentation/test/unit/domain/date-validation.spec.ts
+++ b/src/presentation/test/unit/domain/date-validation.spec.ts
@@ -147,6 +147,18 @@ describe('dateContainsInvalidChars', () => {
     expect(dateContainsInvalidChars('21', '05', 'cccc')).toBe(true);
   });
 
+  it('returns true when day contains full stop', () => {
+    expect(dateContainsInvalidChars('2.', '05', '2025')).toBe(true);
+  });
+
+  it('returns true when month contains full stop', () => {
+    expect(dateContainsInvalidChars('21', '05.', '2025')).toBe(true);
+  });
+
+  it('returns true when year contains full stop', () => {
+    expect(dateContainsInvalidChars('21', '05', '202.')).toBe(true);
+  });
+
   it('returns false when all values are numeric', () => {
     expect(dateContainsInvalidChars('21', '05', '2026')).toBe(false);
   });

--- a/src/presentation/test/unit/domain/date-validation.spec.ts
+++ b/src/presentation/test/unit/domain/date-validation.spec.ts
@@ -147,15 +147,9 @@ describe('dateContainsInvalidChars', () => {
     expect(dateContainsInvalidChars('21', '05', 'cccc')).toBe(true);
   });
 
-  it('returns true when day contains full stop', () => {
+  it('returns true when date contains full stop', () => {
     expect(dateContainsInvalidChars('2.', '05', '2025')).toBe(true);
-  });
-
-  it('returns true when month contains full stop', () => {
     expect(dateContainsInvalidChars('21', '05.', '2025')).toBe(true);
-  });
-
-  it('returns true when year contains full stop', () => {
     expect(dateContainsInvalidChars('21', '05', '202.')).toBe(true);
   });
 

--- a/src/views/add-person-with-significant-control-individual-person.njk
+++ b/src/views/add-person-with-significant-control-individual-person.njk
@@ -78,6 +78,9 @@
                         text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.personTitle,
                         classes: "govuk-label govuk-label--m" 
                     },
+                    hint: {
+                        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.personTitleHint
+                    },
                     errorMessage: props.errors.title if props.errors,
                     items: titleItems
                 }) }}

--- a/src/views/pages/checkYourAnswers/person-with-significant-control.njk
+++ b/src/views/pages/checkYourAnswers/person-with-significant-control.njk
@@ -18,7 +18,7 @@
   rows: [
     {
       key: {
-        text: i18n.personWithSignificantControl.addPersonWithSignificantControl.addIndividualPerson.personTitle
+        text: i18n.checkYourAnswersPage.psc.personTitle
       },
       value: {
         text: item.data.title


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1760


### Change description
This pull request introduces improvements to date validation logic and enhances user-facing text for adding a person with significant control. The main changes include stricter validation for date fields, additional unit tests for invalid date characters, and improved form field labeling with hints in both English and Welsh.

**Date validation improvements:**

* Added a new helper function `isDigitsOnly` and updated `parseDateParts` in `DateValidators.ts` to trim whitespace and ensure all date parts are numeric, preventing invalid input from being parsed as a date.
* Updated the `dateContainsInvalidChars` function to use the new digit-only check, improving detection of invalid characters in date fields.
* Added unit tests to verify that date fields containing full stops are correctly identified as invalid in `date-validation.spec.ts`.

**Form field and localization enhancements:**

* Updated the "Title" field label to "Professional or honorary title (if relevant)" and added a hint ("For example, Dr or Professor") in both English (`personWithSignificantControl.json`) and Welsh localization files. [[1]](diffhunk://#diff-a13359fd5b2b43ca41f5dcc91c0ff5e23b3ef77edb46a72a4c7e2cbea11775ecL58-R59) [[2]](diffhunk://#diff-08a8f668ae4906e2061dd00722686e4f590256fc42429077025a63ff9894e9daL58-R59)
* Added the new hint to the title field in the add individual person form template (`add-person-with-significant-control-individual-person.njk`).


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.