### PR TITLE
LP-1830: Show nationality change on CYA when second nationality removed

### DIFF
--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/update-general-partner-person-check-your-answers.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/update-general-partner-person-check-your-answers.test.ts
@@ -142,6 +142,39 @@ describe("Update general partner check your answers page", () => {
       expect(res.text).not.toContain("4 Service Address Line 1, Line 2, Stoke-On-Trent, Region, England, ST6 3LJ");
       expect(res.text).toContain(enTranslationText.checkYourAnswersPage.update.dateOfChange);
     });
+
+    it("should display the nationality as changed when only the second nationality has been removed", async () => {
+      companyAppointment = new CompanyAppointmentBuilder()
+        .withOfficerRole(OFFICER_ROLE_GENERAL_PARTNER_PERSON)
+        .withName("Doe, John")
+        .withNationality("British,French")
+        .build();
+      appDevDependencies.companyGateway.feedCompanyAppointments([companyAppointment]);
+
+      generalPartner = new GeneralPartnerBuilder()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .isPerson()
+        .withForename("John")
+        .withSurname("Doe")
+        .withNationality1("British")
+        .withUsualResidentialAddressUpdateRequired(false)
+        .withServiceAddressUpdateRequired(false)
+        .withServiceAddress()
+        .withAppointmentId("AP123456")
+        .withDateOfUpdate("2025-01-01")
+        .withKind(PartnerKind.UPDATE_GENERAL_PARTNER_PERSON)
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartner]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain(generalPartner.data?.nationality1);
+      expect(res.text).not.toContain("French");
+      expect(res.text).toContain(enTranslationText.checkYourAnswersPage.update.notUpdated);
+    });
   });
 
   describe("POST update general partner check your answers page", () => {

--- a/src/presentation/test/integration/postTransition/generalPartner/stop-screen-no-change.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/stop-screen-no-change.test.ts
@@ -237,6 +237,34 @@ describe("Stop screen - no change", () => {
 
       appDevDependencies.companyGateway.feedCompanyAppointments([companyAppointmentPerson]);
 
+      const [surname, forename] = companyAppointmentPerson?.name?.split(", ") ?? [];
+
+      generalPartnerPerson = new GeneralPartnerBuilder()
+        .withId(appDevDependencies.generalPartnerGateway.generalPartnerId)
+        .isPerson()
+        .withKind(PartnerKind.UPDATE_GENERAL_PARTNER_PERSON)
+        .withAppointmentId("AP123456P")
+        .withForename(forename)
+        .withSurname(surname)
+        .withNationality1("British")
+        .withDateOfUpdate("2024-10-10")
+        .build();
+
+      appDevDependencies.generalPartnerGateway.feedGeneralPartners([generalPartnerPerson]);
+
+      limitedPartnerPerson = new LimitedPartnerBuilder()
+        .withId(appDevDependencies.limitedPartnerGateway.limitedPartnerId)
+        .isPerson()
+        .withKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON)
+        .withAppointmentId("AP123456P")
+        .withForename(forename)
+        .withSurname(surname)
+        .withNationality1("British")
+        .withDateOfUpdate("2024-10-10")
+        .build();
+
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartnerPerson]);
+
       const res = await request(app).get(whenDidUrl);
 
       expect(res.status).toBe(200);

--- a/src/presentation/test/integration/postTransition/generalPartner/stop-screen-no-change.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/stop-screen-no-change.test.ts
@@ -221,6 +221,31 @@ describe("Stop screen - no change", () => {
   );
 
   it.each([
+    ["GP person", getUrl(WHEN_DID_GENERAL_PARTNER_PERSON_DETAILS_CHANGE_URL)],
+    ["LP person", getUrl(WHEN_DID_LIMITED_PARTNER_PERSON_DETAILS_CHANGE_URL)]
+  ])(
+    "should render the when did page if the second nationality has been removed - %s",
+    async (_partner: string, whenDidUrl: string) => {
+      const companyProfile = new CompanyProfileBuilder().build();
+      const companyAppointmentPerson = new CompanyAppointmentBuilder()
+        .withOfficerRole(OFFICER_ROLE_GENERAL_PARTNER_PERSON)
+        .withAppointmentId("AP123456P")
+        .withCompanyNumber(companyProfile?.data?.companyNumber ?? "")
+        .isPerson()
+        .withNationality("British,French")
+        .build();
+
+      appDevDependencies.companyGateway.feedCompanyAppointments([companyAppointmentPerson]);
+
+      const res = await request(app).get(whenDidUrl);
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain("when-did-");
+    }
+  );
+
+  it.each([
     [
       "GP person - update_usual_residential_address_required",
       getUrl(WHEN_DID_GENERAL_PARTNER_PERSON_DETAILS_CHANGE_URL),

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/update-limited-partner-person-check-your-answers.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/update-limited-partner-person-check-your-answers.test.ts
@@ -140,6 +140,37 @@ describe("Update limited partner check your answers page", () => {
       expect(res.text).not.toContain("4 Service Address Line 1, Line 2, Stoke-On-Trent, Region, England, ST6 3LJ");
       expect(res.text).toContain(enTranslationText.checkYourAnswersPage.update.dateOfChange);
     });
+
+    it("should display the nationality as changed when only the second nationality has been removed", async () => {
+      companyAppointment = new CompanyAppointmentBuilder()
+        .withOfficerRole(OFFICER_ROLE_LIMITED_PARTNER_PERSON)
+        .withName("Doe, John")
+        .withNationality("British,French")
+        .build();
+      appDevDependencies.companyGateway.feedCompanyAppointments([companyAppointment]);
+
+      limitedPartner = new LimitedPartnerBuilder()
+        .withId(appDevDependencies.limitedPartnerGateway.limitedPartnerId)
+        .isPerson()
+        .withForename("John")
+        .withSurname("Doe")
+        .withNationality1("British")
+        .withUsualResidentialAddressUpdateRequired(false)
+        .withAppointmentId("AP123456")
+        .withDateOfUpdate("2025-01-01")
+        .withKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON)
+        .build();
+
+      appDevDependencies.limitedPartnerGateway.feedLimitedPartners([limitedPartner]);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(200);
+
+      expect(res.text).toContain(limitedPartner.data?.nationality1);
+      expect(res.text).not.toContain("French");
+      expect(res.text).toContain(enTranslationText.checkYourAnswersPage.update.notUpdated);
+    });
   });
 
   describe("POST update limited partner check your answers page", () => {

--- a/src/views/pages/checkYourAnswersChange/updatePartner.njk
+++ b/src/views/pages/checkYourAnswersChange/updatePartner.njk
@@ -9,10 +9,14 @@
     {% set name = notUpdated %}
   {% endif %}
 
-  {% set nationalities = macros.formatNationality(item.data.nationality1, i18n) if updateFieldsMap.nationality1 else notUpdated %}
+  {% if updateFieldsMap.nationality1 or updateFieldsMap.nationality2 %}
+    {% set nationalities = macros.formatNationality(item.data.nationality1, i18n) %}
     {% if item.data.nationality2 %}
-      {% set nationalities = macros.formatNationality(item.data.nationality1, i18n) + ", " + macros.formatNationality(item.data.nationality2, i18n) if updateFieldsMap.nationality2 or updateFieldsMap.nationality1 else notUpdated %}
+      {% set nationalities = nationalities + ", " + macros.formatNationality(item.data.nationality2, i18n) %}
     {% endif %}
+  {% else %}
+    {% set nationalities = notUpdated %}
+  {% endif %}
 
   {{ govukSummaryList({
     classes: "govuk-!-margin-bottom-7",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1830


### Change description

Show nationality change on CYA when second nationality removed

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.