### PR TITLE
LP-1962 Gate all routes with ACSP authentication for non-ACSP users

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -101,7 +101,6 @@ export const appConfig = (app: express.Application) => {
   app.use(config.allPathsExceptHealthcheck, authentication);
 
   // keep this after the authentication middleware so that the ACSP number is available in the session for the ACSP authentication middleware
-  // TODO change this to use config.allPathsExceptHealthcheck when we want to apply to all routes except healthcheck
-  app.use(acspAuthentication);
+  app.use(config.allPathsExceptHealthcheck, acspAuthentication);
 
 };

--- a/src/middlewares/acsp-authentication.middleware.ts
+++ b/src/middlewares/acsp-authentication.middleware.ts
@@ -1,15 +1,22 @@
 import { NextFunction, Request, Response } from "express";
 import { acspManageUsersAuthMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import { CHS_URL } from "../config/constants";
+import { NOT_ELIGIBLE_URL, SIGN_OUT_URL } from "../presentation/controller/global/url";
 import { getLoggedInAcspNumber, logger } from "../utils";
+
+// Every route is gated so that only valid ACSP users can use the service, except these:
+//  - the not-eligible stop page, where non-ACSP users are sent (it must render, otherwise the ACSP
+//    check would loop on its own error page);
+//  - sign-out, which must always be available so a user can leave the service.
+// Healthcheck is already excluded where this middleware is mounted (config.allPathsExceptHealthcheck).
+const acspExemptPaths = [NOT_ELIGIBLE_URL.toLowerCase(), SIGN_OUT_URL.toLowerCase()];
 
 export const acspAuthentication = (req: Request, res: Response, next: NextFunction): unknown => {
 
-  const acspRegistrationPathSegment = "/registration/";
-  const acspResumePathSuffix = "/resume";
-  const path: string = req.originalUrl.toLowerCase();
+  // Drop any query string / fragment so the comparison below matches the path exactly.
+  const path: string = req.originalUrl.toLowerCase().split(/[?#]/)[0];
 
-  if (!(path.includes(acspRegistrationPathSegment) || path.endsWith(acspResumePathSuffix) || path === "/")) {
+  if (acspExemptPaths.includes(path)) {
     return next();
   }
 

--- a/src/presentation/test/integration/acsp-authentication.middleware.test.ts
+++ b/src/presentation/test/integration/acsp-authentication.middleware.test.ts
@@ -4,6 +4,7 @@ import { SessionKey } from "@companieshouse/node-session-handler/lib/session/key
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { acspManageUsersAuthMiddleware } from "@companieshouse/web-security-node";
 import { CHS_URL } from "../../../config/constants";
+import { NOT_ELIGIBLE_URL, SIGN_OUT_URL } from "../../controller/global/url";
 import { acspAuthentication } from "../../../middlewares/acsp-authentication.middleware";
 
 jest.unmock("../../../middlewares/acsp-authentication.middleware");
@@ -71,6 +72,92 @@ describe("ACSP authentication middleware", () => {
 
     const config = mockedAcspManageUsersAuthMiddleware.mock.calls[0][0];
     expect(config.returnUrl).toBe("/");
+  });
+
+  it("should delegate to acspManageUsersAuthMiddleware for transition routes", () => {
+    req.originalUrl = "/limited-partnerships/transition/company/LP123456/transaction/123/submission/456/general-partners";
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chsWebUrl: CHS_URL,
+        returnUrl: req.originalUrl,
+        acspNumber: expect.any(String)
+      })
+    );
+  });
+
+  it("should delegate to acspManageUsersAuthMiddleware for post-transition (update) routes", () => {
+    req.originalUrl = "/limited-partnerships/update/company/LP123456/transaction/123/submission/456/general-partner-choice";
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chsWebUrl: CHS_URL,
+        returnUrl: req.originalUrl,
+        acspNumber: expect.any(String)
+      })
+    );
+  });
+
+  it("should delegate to acspManageUsersAuthMiddleware for any other limited-partnerships route", () => {
+    req.originalUrl = "/limited-partnerships/some-other-page";
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).toHaveBeenCalled();
+  });
+
+  it("should not apply the ACSP check to the not-eligible stop page", () => {
+    req.originalUrl = NOT_ELIGIBLE_URL;
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should not apply the ACSP check to the not-eligible stop page regardless of path casing", () => {
+    req.originalUrl = "/limited-partnerships/Not-Eligible";
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should not apply the ACSP check to the not-eligible stop page when it carries a query string", () => {
+    req.originalUrl = `${NOT_ELIGIBLE_URL}?lang=cy`;
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should still gate a route that merely contains 'not-eligible' as a path segment prefix", () => {
+    req.originalUrl = `${NOT_ELIGIBLE_URL}-appeal`;
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chsWebUrl: CHS_URL,
+        returnUrl: req.originalUrl,
+        acspNumber: expect.any(String)
+      })
+    );
+  });
+
+  it("should not apply the ACSP check to the sign-out page", () => {
+    req.originalUrl = SIGN_OUT_URL;
+
+    acspAuthentication(req as Request, res as Response, next as NextFunction);
+
+    expect(mockedAcspManageUsersAuthMiddleware).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
 
 });

--- a/src/presentation/test/integration/global/not-eligible.test.ts
+++ b/src/presentation/test/integration/global/not-eligible.test.ts
@@ -83,7 +83,6 @@ describe("Not Eligible Page", () => {
 
   it.each([
     TRANSITION_START_URL,
-    "/limited-partnerships/Transition/company-number",
     getUrl(TRANSITION_COMPANY_NUMBER_URL),
     getUrl(TRANSITION_GENERAL_PARTNERS_URL),
     getUrl(TRANSITION_LIMITED_PARTNERS_URL),
@@ -96,7 +95,6 @@ describe("Not Eligible Page", () => {
 
   it.each([
     POST_TRANSITION_COMPANY_NUMBER_URL,
-    "/limited-partnerships/Update/company-number",
     getUrl(POST_TRANSITION_LANDING_PAGE_URL),
     getUrl(POST_TRANSITION_GENERAL_PARTNER_CHOICE_URL),
     getUrl(POST_TRANSITION_LIMITED_PARTNER_CHOICE_URL)

--- a/src/presentation/test/integration/global/not-eligible.test.ts
+++ b/src/presentation/test/integration/global/not-eligible.test.ts
@@ -6,9 +6,25 @@ import enTranslationText from "../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../locales/cy/translations.json";
 import * as webSecurityNode from "@companieshouse/web-security-node";
 
-import { NOT_ELIGIBLE_URL, RESUME_JOURNEY_POST_TRANSITION_GENERAL_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_LIMITED_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_PARTNERSHIP_URL, RESUME_JOURNEY_REGISTRATION_OR_TRANSITION_URL } from "../../../controller/global/url";
-import { setLocalesEnabled, testTranslations } from "../../utils";
+import { HEALTHCHECK_URL, NOT_ELIGIBLE_URL, SIGN_OUT_URL, RESUME_JOURNEY_POST_TRANSITION_GENERAL_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_LIMITED_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_PARTNERSHIP_URL, RESUME_JOURNEY_REGISTRATION_OR_TRANSITION_URL } from "../../../controller/global/url";
+import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import { CHECK_YOUR_ANSWERS_URL, GENERAL_PARTNERS_URL, LIMITED_PARTNERS_URL, NAME_URL, TELL_US_ABOUT_PSC_URL } from "../../../controller/registration/url";
+import {
+  COMPANY_NUMBER_URL as TRANSITION_COMPANY_NUMBER_URL,
+  CONTINUE_SAVED_FILING_URL as TRANSITION_CONTINUE_SAVED_FILING_URL,
+  GENERAL_PARTNERS_URL as TRANSITION_GENERAL_PARTNERS_URL,
+  LIMITED_PARTNERS_URL as TRANSITION_LIMITED_PARTNERS_URL,
+  CHECK_YOUR_ANSWERS_URL as TRANSITION_CHECK_YOUR_ANSWERS_URL,
+  TRANSITION_START_URL
+} from "../../../controller/transition/url";
+import {
+  COMPANY_NUMBER_URL as POST_TRANSITION_COMPANY_NUMBER_URL,
+  LANDING_PAGE_URL as POST_TRANSITION_LANDING_PAGE_URL,
+  GENERAL_PARTNER_CHOICE_URL as POST_TRANSITION_GENERAL_PARTNER_CHOICE_URL,
+  LIMITED_PARTNER_CHOICE_URL as POST_TRANSITION_LIMITED_PARTNER_CHOICE_URL
+} from "../../../controller/postTransition/url";
+import { appDevDependencies } from "../../../../config/dev-dependencies";
+import CompanyProfileBuilder from "../../builder/CompanyProfileBuilder";
 
 jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware).mockImplementation(() =>
   (req: Request, res: Response, next: NextFunction) =>
@@ -64,6 +80,50 @@ describe("Not Eligible Page", () => {
     expect(res.status).toBe(403);
     expect(res.text).toContain(enTranslationText.notEligiblePage.title);
   });
+
+  it.each([
+    TRANSITION_START_URL,
+    "/limited-partnerships/Transition/company-number",
+    getUrl(TRANSITION_COMPANY_NUMBER_URL),
+    getUrl(TRANSITION_GENERAL_PARTNERS_URL),
+    getUrl(TRANSITION_LIMITED_PARTNERS_URL),
+    getUrl(TRANSITION_CHECK_YOUR_ANSWERS_URL)
+  ])("should block transition route %s", async (url) => {
+    const res = await request(app).get(url);
+    expect(res.status).toBe(403);
+    expect(res.text).toContain(enTranslationText.notEligiblePage.title);
+  });
+
+  it.each([
+    POST_TRANSITION_COMPANY_NUMBER_URL,
+    "/limited-partnerships/Update/company-number",
+    getUrl(POST_TRANSITION_LANDING_PAGE_URL),
+    getUrl(POST_TRANSITION_GENERAL_PARTNER_CHOICE_URL),
+    getUrl(POST_TRANSITION_LIMITED_PARTNER_CHOICE_URL)
+  ])("should block post-transition route %s", async (url) => {
+    const res = await request(app).get(url);
+    expect(res.status).toBe(403);
+    expect(res.text).toContain(enTranslationText.notEligiblePage.title);
+  });
+
+  it("should block an unrecognised service route", async () => {
+    const res = await request(app).get("/limited-partnerships/some-random-page");
+    expect(res.status).toBe(403);
+    expect(res.text).toContain(enTranslationText.notEligiblePage.title);
+  });
+
+  it("should not block the healthcheck route", async () => {
+    const res = await request(app).get(HEALTHCHECK_URL);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: "OK" });
+  });
+
+  it("should not block the sign-out page", async () => {
+    const res = await request(app).get(`${getUrl(SIGN_OUT_URL)}?lang=en`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
+    testTranslations(res.text, enTranslationText.signOutPage);
+  });
 });
 
 describe("Valid ACSP User", () => {
@@ -90,4 +150,74 @@ describe("Valid ACSP User", () => {
     expect(res.status).toBe(200);
     expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
   });
+});
+
+describe("Valid ACSP User - Transition", () => {
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([]);
+    appDevDependencies.generalPartnerGateway.feedGeneralPartners([]);
+
+    const mocked = jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware);
+    mocked.mockImplementation(() =>
+      (req: Request, res: Response, next: NextFunction) => next()
+    );
+  });
+
+  afterEach(() => {
+    const mocked = jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware);
+    mocked.mockReset();
+  });
+
+  it.each([
+    [getUrl(TRANSITION_GENERAL_PARTNERS_URL), "en"],
+    [getUrl(TRANSITION_LIMITED_PARTNERS_URL), "en"],
+    [getUrl(TRANSITION_GENERAL_PARTNERS_URL), "cy"],
+    [getUrl(TRANSITION_LIMITED_PARTNERS_URL), "cy"]
+  ])("should allow valid ACSP user to access transition route %s - %s", async (url, lang) => {
+    const res = await request(app).get(`${url}?lang=${lang}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
+    // confirm the ACSP middleware actually fired for the transition route (allowed, not skipped)
+    expect(jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware)).toHaveBeenCalled();
+  });
+
+  it("should allow valid ACSP user to reach the transition start page", async () => {
+    const res = await request(app).get(TRANSITION_START_URL);
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain(TRANSITION_CONTINUE_SAVED_FILING_URL);
+    expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
+    expect(jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware)).toHaveBeenCalled();
+  });
+});
+
+describe("Valid ACSP User - Post Transition", () => {
+  beforeEach(() => {
+    setLocalesEnabled(true);
+
+    appDevDependencies.companyGateway.setError(false);
+    appDevDependencies.cacheRepository.feedCache(null);
+    appDevDependencies.companyGateway.feedCompanyProfile(new CompanyProfileBuilder().build().data);
+
+    const mocked = jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware);
+    mocked.mockImplementation(() =>
+      (req: Request, res: Response, next: NextFunction) => next()
+    );
+  });
+
+  afterEach(() => {
+    const mocked = jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware);
+    mocked.mockReset();
+  });
+
+  it.each(["en", "cy"])(
+    "should allow valid ACSP user to access the post-transition company number page - %s",
+    async (lang) => {
+      const res = await request(app).get(`${getUrl(POST_TRANSITION_COMPANY_NUMBER_URL)}?lang=${lang}`);
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
+      expect(jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware)).toHaveBeenCalled();
+    }
+  );
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1962

### Change description

Mount the ACSP authentication middleware on all routes except healthcheck so that only valid ACSP users can access the service. Non-ACSP users are sent to the not-eligible stop page for every route except healthcheck, the not-eligible page itself and sign-out, which stay reachable.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.