### PR TITLE
Feature/lp 2026 add content to acsp stop page

### DIFF
--- a/locales/cy/translations.json
+++ b/locales/cy/translations.json
@@ -422,7 +422,24 @@
     },
 
     "notEligiblePage" : {
-        "title" : "WELSH - You must be an ACSP to use this service"
+        "title" : "WELSH - You must be an Authorised Corporate Service Provider (ACSP) to use this service",
+        "notLinked": "WELSH - You cannot use this service because the email you have signed in with is not linked to an ACSP account.",
+        "onlyAcsp": "WELSH - Only ACSPs can file for limited partnerships.",
+        "whatIsAcsp": "WELSH - An ACSP is an agent, such as an accountant or solicitor, that has registered with Companies House to file on behalf of clients. To register as an ACSP, the agent must be supervised for Anti-Money Laundering (AML) purposes.",
+        "businessRegistered": "WELSH - If you work for a business that is registered as an ACSP",
+        "addAsAcsp": "WELSH - You'll need to ask someone from your business to add you to its ACSP account. To find out more, read the section on how to use your account in our",
+        "acspGuidanceLink": "WELSH - guidance on being an ACSP",
+        "register": "WELSH - If you need to register as an ACSP",
+        "registerGuidance": "WELSH - Read the guidance on registering as an ACSP",
+        "someoneElse": "WELSH - If you're someone else involved with the limited partnership",
+        "needTo": "WELSH - You need to",
+        "findAcsp": "WELSH - find an ACSP",
+        "onBehalf": "WELSH - to file on your behalf.",
+        "links": {
+            "guidance": "https://www.gov.uk/guidance/being-an-authorised-corporate-service-provider.cy",
+            "registering": "https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent.cy",
+            "findAcsp": "https://www.gov.uk/government/publications/list-of-authorised-corporate-service-providers-acsps.cy"
+        }
     },
 
     "pageNotFound" : {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -422,7 +422,24 @@
     },
 
     "notEligiblePage" : {
-        "title" : "You must be an ACSP to use this service"
+        "title" : "You must be an Authorised Corporate Service Provider (ACSP) to use this service",
+        "notLinked": "You cannot use this service because the email you have signed in with is not linked to an ACSP account.",
+        "onlyAcsp": "Only ACSPs can file for limited partnerships.",
+        "whatIsAcsp": "An ACSP is an agent, such as an accountant or solicitor, that has registered with Companies House to file on behalf of clients. To register as an ACSP, the agent must be supervised for Anti-Money Laundering (AML) purposes.",
+        "businessRegistered": "If you work for a business that is registered as an ACSP",
+        "addAsAcsp": "You'll need to ask someone from your business to add you to its ACSP account. To find out more, read the section on how to use your account in our",
+        "acspGuidanceLink": "guidance on being an ACSP",
+        "register": "If you need to register as an ACSP",
+        "registerGuidance": "Read the guidance on registering as an ACSP",
+        "someoneElse": "If you're someone else involved with the limited partnership",
+        "needTo": "You need to",
+        "findAcsp": "find an ACSP",
+        "onBehalf": "to file on your behalf.",
+        "links": {
+            "guidance": "https://www.gov.uk/guidance/being-an-authorised-corporate-service-provider",
+            "registering": "https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent",
+            "findAcsp": "https://www.gov.uk/government/publications/list-of-authorised-corporate-service-providers-acsps"
+        }
     },
 
     "pageNotFound" : {

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -24,7 +24,7 @@ export const authentication = (req: Request, res: Response, next: NextFunction):
 
     next();
   } catch (err) {
-    logger.errorRequest(req, `${err}`);
+    logger.errorRequest(req, JSON.stringify(err));
     next(err);
   }
 };

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -24,7 +24,7 @@ export const authentication = (req: Request, res: Response, next: NextFunction):
 
     next();
   } catch (err) {
-    logger.errorRequest(req, err);
+    logger.errorRequest(req, `${err}`);
     next(err);
   }
 };

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -4,7 +4,7 @@ import { CsrfError, InvalidAcspNumberError } from "@companieshouse/web-security-
 import { getLoggedInUserEmail, logger } from "../utils";
 import * as config from "../config/constants";
 import { PARTNERSHIP_TYPE_URL } from "../presentation/controller/registration/url";
-import { NOT_ELIGIBLE_TEMPLATE } from "../presentation/controller/global/template";
+import { NOT_ELIGIBLE_URL } from "../presentation/controller/global/url";
 
 const pageNotFound = (req: Request, res: Response) => {
   const headerData = getHeaderData(req);
@@ -47,8 +47,12 @@ const invalidAcspNumberErrorHandler = (err: Error, req: Request, res: Response, 
   }
 
   logger.infoRequest(req, `Invalid ACSP error received - ${err.message}`);
+  let URL = NOT_ELIGIBLE_URL;
+  if (req.session?.data?.lang) {
+    URL = NOT_ELIGIBLE_URL + `?lang=${req.session.data.lang}`;
+  };
 
-  return res.status(403).render(NOT_ELIGIBLE_TEMPLATE);
+  return res.redirect(URL);
 };
 
 /**

--- a/src/presentation/test/integration/error-acsp.test.ts
+++ b/src/presentation/test/integration/error-acsp.test.ts
@@ -2,7 +2,6 @@ import { Request, Response, NextFunction } from "express";
 import { InvalidAcspNumberError } from "@companieshouse/web-security-node";
 import { invalidAcspNumberErrorHandler } from "../../../middlewares/error.middleware";
 import { logger } from "../../../utils";
-import { NOT_ELIGIBLE_TEMPLATE } from "../../controller/global/template";
 
 jest.mock("../../../utils/logger");
 
@@ -19,7 +18,8 @@ describe("invalidAcspNumberErrorHandler", () => {
 
     res = {
       status: jest.fn().mockReturnThis(),
-      render: jest.fn()
+      render: jest.fn(),
+      redirect: jest.fn()
     } as any;
 
     next = jest.fn();
@@ -27,13 +27,12 @@ describe("invalidAcspNumberErrorHandler", () => {
   });
 
   describe("when an InvalidAcspNumberError is thrown", () => {
-    it("should render the NOT_ELIGIBLE_TEMPLATE with 403 status", () => {
+    it("should redirect to the not eligible page with 302 status", () => {
       const error = new InvalidAcspNumberError("Invalid ACSP number");
 
       invalidAcspNumberErrorHandler(error, req as Request, res as Response, next as NextFunction);
 
-      expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.render).toHaveBeenCalledWith(NOT_ELIGIBLE_TEMPLATE);
+      expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining("/not-eligible"));
     });
 
     it("should log the error with details", () => {
@@ -55,6 +54,26 @@ describe("invalidAcspNumberErrorHandler", () => {
 
       expect(next).not.toHaveBeenCalled();
     });
+
+    it.each([
+      ["en"],
+      ["cy"]
+    ])("should include lang=%s in the redirect URL when session lang is set", (lang) => {
+      (req as any).session.data.lang = lang;
+      const error = new InvalidAcspNumberError("Invalid ACSP number");
+
+      invalidAcspNumberErrorHandler(error, req as Request, res as Response, next as NextFunction);
+
+      expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining(`lang=${lang}`));
+    });
+
+    it("should not include lang in the redirect URL when session lang is not set", () => {
+      const error = new InvalidAcspNumberError("Invalid ACSP number");
+
+      invalidAcspNumberErrorHandler(error, req as Request, res as Response, next as NextFunction);
+
+      expect(res.redirect).toHaveBeenCalledWith(expect.not.stringContaining("lang="));
+    });
   });
 
   describe("when a non-InvalidAcspNumberError is thrown", () => {
@@ -64,8 +83,7 @@ describe("invalidAcspNumberErrorHandler", () => {
       invalidAcspNumberErrorHandler(error, req as Request, res as Response, next as NextFunction);
 
       expect(next).toHaveBeenCalledWith(error);
-      expect(res.status).not.toHaveBeenCalled();
-      expect(res.render).not.toHaveBeenCalled();
+      expect(res.redirect).not.toHaveBeenCalled();
     });
 
     it("should pass a TypeError to next", () => {

--- a/src/presentation/test/integration/global/not-eligible.test.ts
+++ b/src/presentation/test/integration/global/not-eligible.test.ts
@@ -36,21 +36,16 @@ describe("Not Eligible Page", () => {
   });
 
   it.each([
-    [NAME_URL, "en", enTranslationText],
-    ["/limited-partnerships/Registration/partner-name", "en", enTranslationText],
-    [GENERAL_PARTNERS_URL, "en", enTranslationText],
-    [LIMITED_PARTNERS_URL, "en", enTranslationText],
-    [TELL_US_ABOUT_PSC_URL, "en", enTranslationText],
-    [CHECK_YOUR_ANSWERS_URL, "en", enTranslationText],
-    [NAME_URL, "cy", cyTranslationText],
-    [GENERAL_PARTNERS_URL, "cy", cyTranslationText],
-    [LIMITED_PARTNERS_URL, "cy", cyTranslationText],
-    [TELL_US_ABOUT_PSC_URL, "cy", cyTranslationText],
-    [CHECK_YOUR_ANSWERS_URL, "cy", cyTranslationText]
-  ])("should block registration route %s - %s", async (url, lang, translationText) => {
-    const res = await request(app).get(`${url}?lang=${lang}`);
-    expect(res.status).toBe(403);
-    expect(res.text).toContain(translationText.notEligiblePage.title);
+    [NAME_URL],
+    ["/limited-partnerships/Registration/partner-name"],
+    [GENERAL_PARTNERS_URL],
+    [LIMITED_PARTNERS_URL],
+    [TELL_US_ABOUT_PSC_URL],
+    [CHECK_YOUR_ANSWERS_URL]
+  ])("should block registration route %s", async (url) => {
+    const res = await request(app).get(url);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain(NOT_ELIGIBLE_URL);
   });
 
   it.each([
@@ -61,8 +56,8 @@ describe("Not Eligible Page", () => {
     RESUME_JOURNEY_POST_TRANSITION_PARTNERSHIP_URL
   ])("should block resume route %s", async (url) => {
     const res = await request(app).get(url);
-    expect(res.status).toBe(403);
-    expect(res.text).toContain(enTranslationText.notEligiblePage.title);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain(NOT_ELIGIBLE_URL);
   });
 });
 
@@ -88,6 +83,6 @@ describe("Valid ACSP User", () => {
   ])("should allow valid ACSP user to access registration route %s - %s", async (url, lang) => {
     const res = await request(app).get(`${url}?lang=${lang}`);
     expect(res.status).toBe(200);
-    expect(res.text).not.toContain(enTranslationText.notEligiblePage.title);
+    expect(res.headers.location).toBeUndefined();
   });
 });

--- a/src/presentation/test/integration/global/not-eligible.test.ts
+++ b/src/presentation/test/integration/global/not-eligible.test.ts
@@ -8,7 +8,7 @@ import * as webSecurityNode from "@companieshouse/web-security-node";
 
 import { NOT_ELIGIBLE_URL, RESUME_JOURNEY_POST_TRANSITION_GENERAL_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_LIMITED_PARTNER_URL, RESUME_JOURNEY_POST_TRANSITION_PARTNERSHIP_URL, RESUME_JOURNEY_REGISTRATION_OR_TRANSITION_URL } from "../../../controller/global/url";
 import { setLocalesEnabled, testTranslations } from "../../utils";
-import { CHECK_YOUR_ANSWERS_URL, GENERAL_PARTNERS_URL, LIMITED_PARTNERS_URL, NAME_URL, TELL_US_ABOUT_PSC_URL } from "../../../controller/registration/url";
+import { CHECK_YOUR_ANSWERS_URL, GENERAL_PARTNERS_URL, LIMITED_PARTNERS_URL, NAME_URL, REGISTRATION_START_URL, TELL_US_ABOUT_PSC_URL } from "../../../controller/registration/url";
 
 jest.mocked(webSecurityNode.acspManageUsersAuthMiddleware).mockImplementation(() =>
   (req: Request, res: Response, next: NextFunction) =>
@@ -36,8 +36,8 @@ describe("Not Eligible Page", () => {
   });
 
   it.each([
+    [REGISTRATION_START_URL],
     [NAME_URL],
-    ["/limited-partnerships/Registration/partner-name"],
     [GENERAL_PARTNERS_URL],
     [LIMITED_PARTNERS_URL],
     [TELL_US_ABOUT_PSC_URL],

--- a/src/views/not-eligible.njk
+++ b/src/views/not-eligible.njk
@@ -8,6 +8,19 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ i18n.notEligiblePage.title }}</h1>
+
+      <p class="govuk-body">{{ i18n.notEligiblePage.notLinked }}</p>
+      <p class="govuk-body">{{ i18n.notEligiblePage.onlyAcsp }}</p>
+      <p class="govuk-body">{{ i18n.notEligiblePage.whatIsAcsp }}</p>
+
+      <h2 class="govuk-heading-m">{{ i18n.notEligiblePage.businessRegistered }}</h2>
+      <p class="govuk-body">{{ i18n.notEligiblePage.addAsAcsp }} <a class="govuk-link govuk-link--no-visited-state govuk-body-m" rel="noreferrer noopener" target="_blank" href="{{i18n.notEligiblePage.links.guidance}}">{{ i18n.notEligiblePage.acspGuidanceLink }}</a>.</p>
+      
+      <h2 class="govuk-heading-m">{{ i18n.notEligiblePage.register }}</h2>
+      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state govuk-body-m" rel="noreferrer noopener" target="_blank" href="{{i18n.notEligiblePage.links.registering}}">{{ i18n.notEligiblePage.registerGuidance }}</a>.</p>
+
+      <h2 class="govuk-heading-m">{{ i18n.notEligiblePage.someoneElse }}</h2>
+      <p class="govuk-body">{{ i18n.notEligiblePage.needTo }} <a class="govuk-link govuk-link--no-visited-state govuk-body-m" rel="noreferrer noopener" target="_blank" href="{{i18n.notEligiblePage.links.findAcsp}}">{{ i18n.notEligiblePage.findAcsp }}</a> {{ i18n.notEligiblePage.onBehalf }}</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2026


### Change description
This pull request updates the handling and user experience for users who are not eligible (i.e., not Authorised Corporate Service Providers, or ACSPs) to use the service. The main improvements include redirecting ineligible users to a dedicated "not eligible" page (instead of rendering it directly), enhancing the content and guidance on that page, and updating tests and translations to reflect these changes.

**Error handling and redirection:**

* The `invalidAcspNumberErrorHandler` middleware now redirects users to the `/not-eligible` page (with an optional `lang` query parameter for language support) instead of rendering the template directly. This ensures a more consistent user experience and enables better language handling.
* Tests have been updated to verify the new redirect behavior, including checking for the presence of the `lang` parameter when set in the session, and ensuring that non-ACSP errors are handled appropriately. [[1]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L22-R35) [[2]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124R57-R76) [[3]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L67-R86) [[4]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL39-R48) [[5]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL64-R60) [[6]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL91-R86)

**User interface and content improvements:**

* The "not eligible" page (`not-eligible.njk`) now includes expanded guidance for users, such as explanations of what an ACSP is, instructions for joining a business's ACSP account, registration steps, and links to relevant external guidance.
* English and Welsh translation files have been updated with new and improved content for the "not eligible" page, including all new guidance strings and associated URLs. [[1]](diffhunk://#diff-4d8ba88e07a57383d74328c5328ad12e8ead5dab8dac07d79ef08b7d69488b8eL425-R442) [[2]](diffhunk://#diff-8f62eb8842cefceb566fdd16acb25aa65adeacb1132a291d29efc5fd902ac74cL425-R442)

**Code and test maintenance:**

* Unused imports related to the old template rendering approach have been removed from middleware and test files. [[1]](diffhunk://#diff-8254f6fe3196e8c67636cbe06ef46e54cda1bc06ca721d6874639fad0f9f441aL7-R7) [[2]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L5)
* Minor logging improvements were made to ensure error objects are stringified for better log output.

These changes collectively improve the clarity, accessibility, and maintainability of the not-eligible user experience.

---

**References:**
- Error handling and redirection: [[1]](diffhunk://#diff-8254f6fe3196e8c67636cbe06ef46e54cda1bc06ca721d6874639fad0f9f441aR50-R55) [[2]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L22-R35) [[3]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124R57-R76) [[4]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L67-R86) [[5]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL39-R48) [[6]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL64-R60) [[7]](diffhunk://#diff-2ff68bb962c56a0c8cd1a7fd6f3b6815e9db071480aabb0198627306377b01caL91-R86)
- User interface and content improvements: [[1]](diffhunk://#diff-eea8d1ad8fc367dcc240758f3ba39cb3d0330464d5a5c0acb5b3cb55dd3e3e13R11-R23) [[2]](diffhunk://#diff-4d8ba88e07a57383d74328c5328ad12e8ead5dab8dac07d79ef08b7d69488b8eL425-R442) [[3]](diffhunk://#diff-8f62eb8842cefceb566fdd16acb25aa65adeacb1132a291d29efc5fd902ac74cL425-R442)
- Code and test maintenance: [[1]](diffhunk://#diff-8254f6fe3196e8c67636cbe06ef46e54cda1bc06ca721d6874639fad0f9f441aL7-R7) [[2]](diffhunk://#diff-2b128a4a1bfdcdc51f34101a7f703ae7e1224a702796c95968f57d3cb7ee0124L5) [[3]](diffhunk://#diff-0a2109c3399b8531b614b7a4450dabad2c304dd805777e071265d08a84e4b8aaL27-R27)


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.