### PR TITLE
LP-2027 Match capital contribution max length to CHIPS

### DIFF
--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -4,7 +4,7 @@
             "valueRequired": "WELSH - Enter the total value of all monetary and non-monetary contributions",
             "twoDecimalPlaces": "WELSH - Value must be a number with 2 decimal places",
             "moreThanZero": "WELSH - Value must be 0.01 or more",
-            "maxValue": "WELSH - Value must be 99999999.99 or less",
+            "maxValue": "WELSH - The capital contribution value cannot have more than 8 digits before the decimal",
             "noSymbols": "WELSH - Value must not include currency symbols like £, $ and €",
             "noComma": "WELSH - Value must not include a comma",
             "atLeastOneType": "WELSH - Select at least one type of contribution",

--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -4,6 +4,7 @@
             "valueRequired": "WELSH - Enter the total value of all monetary and non-monetary contributions",
             "twoDecimalPlaces": "WELSH - Value must be a number with 2 decimal places",
             "moreThanZero": "WELSH - Value must be 0.01 or more",
+            "maxValue": "WELSH - Value must be 99999999.99 or less",
             "noSymbols": "WELSH - Value must not include currency symbols like £, $ and €",
             "noComma": "WELSH - Value must not include a comma",
             "atLeastOneType": "WELSH - Select at least one type of contribution",

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -4,7 +4,7 @@
             "valueRequired": "Enter the total value of all monetary and non-monetary contributions",
             "twoDecimalPlaces": "Value must be a number with 2 decimal places",
             "moreThanZero": "Value must be 0.01 or more",
-            "maxValue": "Value must be 99999999.99 or less",
+            "maxValue": "The capital contribution value cannot have more than 8 digits before the decimal",
             "noSymbols": "Value must not include currency symbols like £, $ and €",
             "noComma": "Value must not include a comma",
             "atLeastOneType": "Select at least one type of contribution",

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -4,6 +4,7 @@
             "valueRequired": "Enter the total value of all monetary and non-monetary contributions",
             "twoDecimalPlaces": "Value must be a number with 2 decimal places",
             "moreThanZero": "Value must be 0.01 or more",
+            "maxValue": "Value must be 99999999.99 or less",
             "noSymbols": "Value must not include currency symbols like £, $ and €",
             "noComma": "Value must not include a comma",
             "atLeastOneType": "Select at least one type of contribution",

--- a/src/application/service/utils/capitalContributionValidation.ts
+++ b/src/application/service/utils/capitalContributionValidation.ts
@@ -1,6 +1,10 @@
 import UIErrors from "../../../domain/entities/UIErrors";
 import { symbols } from "./currencies";
 
+// CHIPS enforces a maximum of 10 digits in total with up to 2 decimal places
+// (CheckMaxDecimalValueRule precision=10, scale=2), giving a maximum value of 99999999.99.
+const MAX_DIGITS = 10;
+
 const capitalContributionValidation = (data: Record<string, string | string[]>, i18n: any): void => {
   const uiErrors = new UIErrors();
 
@@ -32,6 +36,8 @@ const contributionCurrencyValueValidation = (data: Record<string, any>, uiErrors
     uiErrors.setWebError(field, i18n?.errorMessages?.capitalContribution?.twoDecimalPlaces);
   } else if (!isGreaterThanZero(data.contribution_currency_value)) {
     uiErrors.setWebError(field, i18n?.errorMessages?.capitalContribution?.moreThanZero);
+  } else if (!isWithinMaxDigits(data.contribution_currency_value)) {
+    uiErrors.setWebError(field, i18n?.errorMessages?.capitalContribution?.maxValue);
   }
 };
 
@@ -45,6 +51,14 @@ const has2Decimal = (value: string) => {
 
 const isGreaterThanZero = (value: string) => {
   return parseFloat(value) > 0;
+};
+
+// Precondition: only call once has2Decimal has confirmed exactly 2 decimal places.
+// Stripping the decimal point and leading zeros then gives the count of significant
+// digits, which mirrors CHIPS's BigDecimal precision (max 10 = 8 integer + 2 decimal).
+const isWithinMaxDigits = (value: string) => {
+  const significantDigits = value.replace(/\D/g, "").replace(/^0+/, "");
+  return significantDigits.length <= MAX_DIGITS;
 };
 
 const hasSymbol = (str: string, symbols: string[]): boolean => {

--- a/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
+++ b/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
@@ -38,13 +38,13 @@ describe("Gateway capital contribition validation test suite", () => {
         "100000000.00",
         { ...data, contribution_currency_value: "100000000.00" },
         dataKeys[1],
-        "Value must be 99999999.99 or less"
+        "The capital contribution value cannot have more than 8 digits before the decimal"
       ],
       [
         "99999999999.99",
         { ...data, contribution_currency_value: "99999999999.99" },
         dataKeys[1],
-        "Value must be 99999999.99 or less"
+        "The capital contribution value cannot have more than 8 digits before the decimal"
       ],
       [
         "£100.00",

--- a/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
+++ b/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
@@ -35,6 +35,18 @@ describe("Gateway capital contribition validation test suite", () => {
       ],
       ["000.00", { ...data, contribution_currency_value: "000.00" }, dataKeys[1], "Value must be 0.01 or more"],
       [
+        "100000000.00",
+        { ...data, contribution_currency_value: "100000000.00" },
+        dataKeys[1],
+        "Value must be 99999999.99 or less"
+      ],
+      [
+        "99999999999.99",
+        { ...data, contribution_currency_value: "99999999999.99" },
+        dataKeys[1],
+        "Value must be 99999999.99 or less"
+      ],
+      [
         "£100.00",
         { ...data, contribution_currency_value: "£100.00" },
         dataKeys[1],
@@ -81,6 +93,21 @@ describe("Gateway capital contribition validation test suite", () => {
         })
       );
     });
+
+    it.each(["0.01", "12345678.90", "99999999.98", "99999999.99", "099999999.99"])(
+      "should not throw an error for a valid capital contribution value - %s",
+      (contribution_currency_value) => {
+        let thrownError: UIErrors | null = null;
+
+        try {
+          capitalContributionValidation({ ...data, contribution_currency_value }, i18nErrorsEn);
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeNull();
+      }
+    );
 
     it("should throw an error for invalid capital contribution - welsh", () => {
       let thrownError: UIErrors | null = null;


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-2027


### Change description

CHIPS enforces CheckMaxDecimalValueRule(precision=10, scale=2), allowing a maximum of 8 digits before the decimal point and 2 after (max value 99999999.99). The web form previously allowed up to 12 digits before the decimal, so values accepted on Web were rejected downstream by CHIPS.

Add a max-digits check to the capital contribution validation that counts significant digits (ignoring leading zeros, matching the CHIPS BigDecimal precision) and rejects anything over 99999999.99 with a new maxValue error message (EN + CY). Add unit tests for the new boundary and valid cases.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.