### PR TITLE
LP-1944 Fix for address validation firing when selecting enter manual from postcode lookup list screen

### DIFF
--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -295,10 +295,11 @@ class AddressLookUpController extends AbstractController {
           return;
         }
 
-        this.addAddressToCache(request, response, pageType, ids.transactionId, address);
+        this.addToCache(request, response, ids.transactionId, pageRouting?.data?.[AddressCacheKeys.postcodeCacheKey], address?.postal_code);
 
         // if exact match - redirect to confirm page
         if (address?.postal_code && address?.premises && address?.address_line_1) {
+          this.addToCache(request, response, ids.transactionId, pageRouting?.data?.[AddressCacheKeys.addressCacheKey], address);
           const url = super.insertIdsInUrl(pageRouting?.data?.confirmAddressUrl, ids, request.url);
 
           response.redirect(url);
@@ -634,8 +635,8 @@ class AddressLookUpController extends AbstractController {
     let redirectToConfirm = "";
 
     if (CHOOSE_PAGES.has(pageRouting.pageType)) {
-      const cacheKey = pageRouting.data?.[AddressCacheKeys.addressCacheKey];
-      const postcode = cache[cacheKey]?.postal_code;
+      const cacheKey = pageRouting.data?.[AddressCacheKeys.postcodeCacheKey];
+      const postcode = cache[cacheKey];
 
       addressList = await this.addressService.getAddressListForPostcode(tokens, postcode);
 
@@ -647,21 +648,19 @@ class AddressLookUpController extends AbstractController {
     return { addressList, redirectToConfirm };
   }
 
-  private addAddressToCache(
+  private addToCache(
     request: Request,
     response: Response,
-    pageType: any,
     transactionId: string,
-    address: Address
+    key: string,
+    value: any
   ) {
     const cacheById = this.cacheService.getDataFromCacheById(request.signedCookies, transactionId);
-    const addressRouting = this.getAddressRouting(request.url);
-    const pageRouting = super.getRouting(addressRouting, pageType, request);
 
     const cache = this.cacheService.addDataToCache(request.signedCookies, {
       [transactionId]: {
         ...cacheById,
-        [pageRouting?.data?.[AddressCacheKeys.addressCacheKey]]: address
+        [key]: value
       }
     });
     response.cookie(APPLICATION_CACHE_KEY, cache, cookieOptions);

--- a/src/presentation/controller/addressLookUp/Controller.ts
+++ b/src/presentation/controller/addressLookUp/Controller.ts
@@ -653,7 +653,7 @@ class AddressLookUpController extends AbstractController {
     response: Response,
     transactionId: string,
     key: string,
-    value: any
+    value: string | Address
   ) {
     const cacheById = this.cacheService.getDataFromCacheById(request.signedCookies, transactionId);
 

--- a/src/presentation/controller/addressLookUp/routing/postTransition/generalPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/postTransition/generalPartner.ts
@@ -11,14 +11,16 @@ import * as url from "../../url/postTransition";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const usualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const postTransitionAddressRoutingTerritoryChoiceGeneralPartnerUsualResidentialAddress = {
@@ -91,7 +93,8 @@ const usualResidentialAddress = [
 
 const correspondenceAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "service_address",
-  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "sa_postcode"
 };
 
 const postTransitionAddressRoutingTerritoryChoiceGeneralPartnerCorrespondenceAddress = {
@@ -165,7 +168,8 @@ const correspondenceAddress = [
 
 const principalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const postTransitionAddressRoutingTerritoryChoiceGeneralPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/postTransition/limitedPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/postTransition/limitedPartner.ts
@@ -4,14 +4,16 @@ import * as url from "../../url/postTransition";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const usualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const postTransitionAddressRoutingTerritoryChoiceLimitedPartnerUsualResidentialAddress = {
@@ -84,7 +86,8 @@ const usualResidentialAddress = [
 
 const principalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const postTransitionAddressRoutingTerritoryChoiceLimitedPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/postTransition/routing.ts
+++ b/src/presentation/controller/addressLookUp/routing/postTransition/routing.ts
@@ -6,7 +6,8 @@ import limitedPartnerPostTransitionAddressRouting from "./limitedPartner";
 
 export enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 const postTransitionAddressRouting: PagesRouting = new Map<PageType, PageRouting>();

--- a/src/presentation/controller/addressLookUp/routing/registration/generalPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/generalPartner.ts
@@ -8,14 +8,16 @@ import * as url from "../../url/registration";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const usualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoiceGeneralPartnerUsualResidentialAddress = {
@@ -87,7 +89,8 @@ const usualResidentialAddress = [
 
 const correspondenceAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "service_address",
-  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "sa_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoiceGeneralPartnerCorrespondenceAddress = {
@@ -158,7 +161,8 @@ const correspondenceAddress = [
 
 const principalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoiceGeneralPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/registration/limitedPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/limitedPartner.ts
@@ -8,14 +8,16 @@ import * as url from "../../url/registration";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const limitedPartnerUsualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoiceLimitedPartnerUsualResidentialAddress = {
@@ -86,7 +88,8 @@ const usualResidentialAddress = [
 
 const limitedPartnerPrincipalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoiceLimitedPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/registration/limitedPartnership.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/limitedPartnership.ts
@@ -4,13 +4,15 @@ import * as url from "../../url/registration";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // Registered Office Address
 
 const registeredOfficeAddressCacheKeys = {
-  [AddressCacheKeys.addressCacheKey]: "registered_office_address"
+  [AddressCacheKeys.addressCacheKey]: "registered_office_address",
+  [AddressCacheKeys.postcodeCacheKey]: "roa_postcode"
 };
 
 const registrationAddressRoutingPostcodeRegisteredOfficeAddress = {
@@ -67,7 +69,8 @@ const registeredOfficeAddress = [
 // principal place of business
 
 const principalPlaceOfBusinessAddressCacheKeys = {
-  [AddressCacheKeys.addressCacheKey]: "principal_place_of_business_address"
+  [AddressCacheKeys.addressCacheKey]: "principal_place_of_business_address",
+  [AddressCacheKeys.postcodeCacheKey]: "ppob_postcode"
 };
 
 const registrationAddressRoutingPostcodePrincipalPlaceOfBusinessAddress = {

--- a/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/personWithSignificantControl.ts
@@ -9,14 +9,16 @@ import * as url from "../../url/registration";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // principal office address - Relevant Legal Entity
 
 const personWithSignificantControlPrincipalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlRelevantLegalEntityPrincipalOfficeAddress = {
@@ -148,7 +150,8 @@ const registrationAddressRoutingConfirmPersonWithSignificantControlOtherRegistra
 
 const personWithSignificantControlUsualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlIndividualPersonUsualResidentialAddress = {
@@ -215,7 +218,8 @@ const registrationAddressRoutingConfirmPersonWithSignificantControlIndividualPer
 
 const personWithSignificantControlCorrespondenceAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "service_address",
-  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "sa_postcode"
 };
 
 const registrationAddressRoutingTerritoryChoicePersonWithSignificantControlIndividualPersonCorrespondenceAddress = {

--- a/src/presentation/controller/addressLookUp/routing/registration/routing.ts
+++ b/src/presentation/controller/addressLookUp/routing/registration/routing.ts
@@ -7,7 +7,8 @@ import personWithSignificantControlRegistrationRouting from "./personWithSignifi
 
 export enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 const registrationAddressRouting: PagesRouting = new Map<PageType, PageRouting>();

--- a/src/presentation/controller/addressLookUp/routing/transition/generalPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/transition/generalPartner.ts
@@ -8,14 +8,16 @@ import * as url from "../../url/transition";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const usualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const transitionAddressRoutingTerritoryChoiceGeneralPartnerUsualResidentialAddress = {
@@ -87,7 +89,8 @@ const usualResidentialAddress = [
 
 const correspondenceAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "service_address",
-  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "sa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "sa_postcode"
 };
 
 const transitionAddressRoutingTerritoryChoiceGeneralPartnerCorrespondenceAddress = {
@@ -158,7 +161,8 @@ const correspondenceAddress = [
 
 const principalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const transitionAddressRoutingTerritoryChoiceGeneralPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/transition/limitedPartner.ts
+++ b/src/presentation/controller/addressLookUp/routing/transition/limitedPartner.ts
@@ -8,14 +8,16 @@ import * as url from "../../url/transition";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // usual residential address - Person
 
 const limitedPartnerUsualResidentialAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "usual_residential_address",
-  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "ura_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "ura_postcode"
 };
 
 const transitionAddressRoutingTerritoryChoiceLimitedPartnerUsualResidentialAddress = {
@@ -84,7 +86,8 @@ const usualResidentialAddress = [
 
 const limitedPartnerPrincipalOfficeAddressCacheKeys = {
   [AddressCacheKeys.addressCacheKey]: "principal_office_address",
-  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice"
+  [AddressCacheKeys.territoryCacheKey]: "poa_territory_choice",
+  [AddressCacheKeys.postcodeCacheKey]: "poa_postcode"
 };
 
 const transitionAddressRoutingTerritoryChoiceLimitedPartnerPrincipalOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/transition/limitedPartnership.ts
+++ b/src/presentation/controller/addressLookUp/routing/transition/limitedPartnership.ts
@@ -4,13 +4,15 @@ import * as url from "../../url/transition";
 
 enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 // Registered Office Address
 
 const registeredOfficeAddressCacheKeys = {
-  [AddressCacheKeys.addressCacheKey]: "registered_office_address"
+  [AddressCacheKeys.addressCacheKey]: "registered_office_address",
+  [AddressCacheKeys.postcodeCacheKey]: "roa_postcode"
 };
 
 const transitionAddressRoutingPostcodeRegisteredOfficeAddress = {

--- a/src/presentation/controller/addressLookUp/routing/transition/routing.ts
+++ b/src/presentation/controller/addressLookUp/routing/transition/routing.ts
@@ -6,7 +6,8 @@ import limitedPartnerTransitionRouting from "./limitedPartner";
 
 export enum AddressCacheKeys {
   addressCacheKey = "addressCacheKey",
-  territoryCacheKey = "territoryCacheKey"
+  territoryCacheKey = "territoryCacheKey",
+  postcodeCacheKey = "postcodeCacheKey"
 }
 
 const transitionAddressRouting: PagesRouting = new Map<PageType, PageRouting>();

--- a/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-correspondence-address.test.ts
@@ -38,14 +38,7 @@ describe("Choose general partner correspondence address page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        service_address: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        sa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -131,6 +124,7 @@ describe("Choose general partner correspondence address page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          sa_postcode: "ST6 3LJ",
           service_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-principal-office-address.test.ts
@@ -42,14 +42,7 @@ describe("Choose principal office address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
 
@@ -120,6 +113,7 @@ describe("Choose principal office address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
@@ -32,14 +32,7 @@ describe("Choose usual residential address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
 
@@ -132,6 +125,7 @@ describe("Choose usual residential address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -128,14 +128,7 @@ describe("Postcode general partner's correspondence address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            service_address: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            sa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
@@ -133,14 +133,7 @@ describe("Postcode general partner's principal office address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
@@ -140,14 +140,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -168,7 +161,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/postTransition/limitedPartner/address/choose-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/address/choose-limited-partner-principal-office-address.test.ts
@@ -43,14 +43,7 @@ describe("Choose principal office address of the limited partner page", () => {
 
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
 
@@ -121,6 +114,7 @@ describe("Choose principal office address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/postTransition/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
@@ -40,14 +40,7 @@ describe("Choose usual residential address of the limited partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
 
@@ -118,6 +111,7 @@ describe("Choose usual residential address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/postTransition/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
@@ -127,14 +127,7 @@ describe("Postcode limited partner's principal office address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/postTransition/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
@@ -131,14 +131,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -159,7 +152,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/address/choose-principal-place-of-business-address.test.ts
+++ b/src/presentation/test/integration/registration/address/choose-principal-place-of-business-address.test.ts
@@ -30,14 +30,7 @@ describe("Choose Principal Place Of Business Address Page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_place_of_business_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ppob_postcode: "ST6 3LJ"
       }
     });
   });
@@ -105,6 +98,7 @@ describe("Choose Principal Place Of Business Address Page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ppob_postcode: "ST6 3LJ",
           principal_place_of_business_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/address/choose-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/choose-registered-office-address.test.ts
@@ -28,14 +28,7 @@ describe("Choose Registered Office Address Page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["registered_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        roa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -103,6 +96,7 @@ describe("Choose Registered Office Address Page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          roa_postcode: "ST6 3LJ",
           registered_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/address/postcode-principal-place-of-business-address.test.ts
+++ b/src/presentation/test/integration/registration/address/postcode-principal-place-of-business-address.test.ts
@@ -93,14 +93,7 @@ describe("Postcode Principal Place Of Business Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_place_of_business_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ppob_postcode: "ST6 3LJ"
           }
         }
       });
@@ -121,7 +114,8 @@ describe("Postcode Principal Place Of Business Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_place_of_business_address"]: {
+            ppob_postcode: "ST6 3LJ",
+            principal_place_of_business_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/address/postcode-registered-office-address.test.ts
+++ b/src/presentation/test/integration/registration/address/postcode-registered-office-address.test.ts
@@ -94,14 +94,7 @@ describe("Postcode Registered Office Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [config.APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["registered_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            roa_postcode: "ST6 3LJ"
           }
         }
       });
@@ -122,7 +115,8 @@ describe("Postcode Registered Office Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [config.APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["registered_office_address"]: {
+            roa_postcode: "ST6 3LJ",
+            registered_office_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-correspondence-address.test.ts
@@ -30,14 +30,7 @@ describe("Choose general partner correspondence address page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        service_address: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        sa_postcode: "ST6 3LJ"
       }
     });
 
@@ -110,6 +103,7 @@ describe("Choose general partner correspondence address page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          sa_postcode: "ST6 3LJ",
           service_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-principal-office-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose principal office address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -110,6 +103,7 @@ describe("Choose principal office address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
@@ -38,14 +38,7 @@ describe("Choose usual residential address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
   });
@@ -111,6 +104,7 @@ describe("Choose usual residential address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -111,14 +111,7 @@ describe("Postcode general partner's correspondence address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            service_address: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            sa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
@@ -121,14 +121,7 @@ describe("Postcode general partner's principal office address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
@@ -124,14 +124,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -152,7 +145,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
@@ -30,14 +30,7 @@ describe("Choose usual residential address of the limited partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
 
@@ -110,6 +103,7 @@ describe("Choose usual residential address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/limitedPartner/address/choose-limited-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/choose-limited-principal-office-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose principal office address of the limited partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        principal_office_address: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -110,6 +103,7 @@ describe("Choose principal office address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
@@ -122,14 +122,7 @@ describe("Postcode limited partner principal office address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });
@@ -150,7 +143,8 @@ describe("Postcode limited partner principal office address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
+            poa_postcode: "ST6 3LJ",
+            principal_office_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
@@ -124,14 +124,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -152,7 +145,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-correspondence-address.test.ts
@@ -42,14 +42,7 @@ describe("Choose correspondence address individual person page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["service_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        sa_postcode: "ST6 3LJ"
       }
     });
 
@@ -140,6 +133,7 @@ describe("Choose correspondence address individual person page", () => {
 
       expect(appDevDependencies.cacheRepository.cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          sa_postcode: "ST6 3LJ",
           service_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-principal-office-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose principal office address of the person with significant control
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
 
@@ -169,6 +162,7 @@ describe("Choose principal office address of the person with significant control
 
         expect(appDevDependencies.cacheRepository.cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
           [appDevDependencies.transactionGateway.transactionId]: {
+            poa_postcode: "ST6 3LJ",
             principal_office_address: {
               postal_code: "ST6 3LJ",
               premises: "4",

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/choose-person-with-significant-control-usual-residential-address.test.ts
@@ -42,14 +42,7 @@ describe("Choose usual residential address individual person page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
 
@@ -140,6 +133,7 @@ describe("Choose usual residential address individual person page", () => {
 
       expect(appDevDependencies.cacheRepository.cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-correspondence-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-correspondence-address.test.ts
@@ -110,19 +110,11 @@ describe("Postcode individual person correspondence address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["service_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            sa_postcode: "ST6 3LJ"
           }
         }
       });
-    }
-    );
+    });
 
     it("should validate the post code then redirect to the next page even if LP jurisdiction is not in the same locality", async () => {
       const res = await request(app).post(URL).send({

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-principal-office-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-principal-office-address.test.ts
@@ -116,14 +116,7 @@ describe("Postcode person with significant control's principal office address pa
         expect(appDevDependencies.cacheRepository.cache).toEqual({
           [APPLICATION_CACHE_KEY]: {
             [appDevDependencies.transactionGateway.transactionId]: {
-              ["principal_office_address"]: {
-                postal_code: "ST6 3LJ",
-                address_line_1: "",
-                address_line_2: "",
-                locality: "",
-                country: "",
-                premises: ""
-              }
+              poa_postcode: "ST6 3LJ"
             }
           }
         });

--- a/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/address/postcode-psc-usual-residential-address.test.ts
@@ -110,14 +110,7 @@ describe("Postcode individual person usual residential address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/transition/address/choose-registered-office-address.test.ts
+++ b/src/presentation/test/integration/transition/address/choose-registered-office-address.test.ts
@@ -29,14 +29,7 @@ describe("Choose Registered Office Address Page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["registered_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        roa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -106,6 +99,7 @@ describe("Choose Registered Office Address Page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          roa_postcode: "ST6 3LJ",
           registered_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/address/postcode-registered-office-address.test.ts
+++ b/src/presentation/test/integration/transition/address/postcode-registered-office-address.test.ts
@@ -94,14 +94,7 @@ describe("Postcode Registered Office Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [config.APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["registered_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            roa_postcode: "ST6 3LJ"
           }
         }
       });
@@ -122,7 +115,8 @@ describe("Postcode Registered Office Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [config.APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["registered_office_address"]: {
+            roa_postcode: "ST6 3LJ",
+            registered_office_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-correspondence-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose general partner correspondence address page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        service_address: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        sa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -110,6 +103,7 @@ describe("Choose general partner correspondence address page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          sa_postcode: "ST6 3LJ",
           service_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-principal-office-address.test.ts
@@ -38,14 +38,7 @@ describe("Choose principal office address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["principal_office_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -111,6 +104,7 @@ describe("Choose principal office address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/choose-general-partner-usual-residential-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose usual residential address of the general partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
   });
@@ -110,6 +103,7 @@ describe("Choose usual residential address of the general partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-correspondence-address.test.ts
@@ -112,14 +112,7 @@ describe("Postcode general partner's correspondence address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            service_address: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            sa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-principal-office-address.test.ts
@@ -120,14 +120,7 @@ describe("Postcode general partner's principal office address page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });

--- a/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/transition/generalPartner/address/postcode-general-partner-usual-residential-address.test.ts
@@ -124,14 +124,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -152,7 +145,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/transition/limitedPartner/address/choose-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/address/choose-limited-partner-principal-office-address.test.ts
@@ -38,14 +38,7 @@ describe("Choose principal office address of the limited partner page", () => {
 
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        principal_office_address: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        poa_postcode: "ST6 3LJ"
       }
     });
   });
@@ -121,6 +114,7 @@ describe("Choose principal office address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          poa_postcode: "ST6 3LJ",
           principal_office_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/address/choose-limited-partner-usual-residential-address.test.ts
@@ -37,14 +37,7 @@ describe("Choose usual residential address of the limited partner page", () => {
     appDevDependencies.addressLookUpGateway.setError(false);
     appDevDependencies.cacheRepository.feedCache({
       [appDevDependencies.transactionGateway.transactionId]: {
-        ["usual_residential_address"]: {
-          postal_code: "ST6 3LJ",
-          premises: "",
-          address_line_1: "",
-          address_line_2: "",
-          locality: "",
-          country: ""
-        }
+        ura_postcode: "ST6 3LJ"
       }
     });
   });
@@ -110,6 +103,7 @@ describe("Choose usual residential address of the limited partner page", () => {
       const cache = appDevDependencies.cacheRepository.cache;
       expect(cache?.[`${config.APPLICATION_CACHE_KEY}`]).toEqual({
         [appDevDependencies.transactionGateway.transactionId]: {
+          ura_postcode: "ST6 3LJ",
           usual_residential_address: {
             postal_code: "ST6 3LJ",
             premises: "4",

--- a/src/presentation/test/integration/transition/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/address/postcode-limited-partner-principal-office-address.test.ts
@@ -122,14 +122,7 @@ describe("Postcode limited partner principal office address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            poa_postcode: "ST6 3LJ"
           }
         }
       });
@@ -150,7 +143,8 @@ describe("Postcode limited partner principal office address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["principal_office_address"]: {
+            poa_postcode: "ST6 3LJ",
+            principal_office_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",

--- a/src/presentation/test/integration/transition/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
+++ b/src/presentation/test/integration/transition/limitedPartner/address/postcode-limited-partner-usual-residential-address.test.ts
@@ -124,14 +124,7 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
-              postal_code: "ST6 3LJ",
-              address_line_1: "",
-              address_line_2: "",
-              locality: "",
-              country: "",
-              premises: ""
-            }
+            ura_postcode: "ST6 3LJ"
           }
         }
       });
@@ -152,7 +145,8 @@ describe("Postcode Usual Residential Address Page", () => {
       expect(appDevDependencies.cacheRepository.cache).toEqual({
         [APPLICATION_CACHE_KEY]: {
           [appDevDependencies.transactionGateway.transactionId]: {
-            ["usual_residential_address"]: {
+            ura_postcode: "ST6 3LJ",
+            usual_residential_address: {
               postal_code: "ST6 3LJ",
               premises: "2",
               address_line_1: "DUNCALF STREET",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1944


### Change description
When using a postcode to look up a list of addresses, the postcode is now stored in a separate cache field (new cache key) instead of storing it in an empty address. This was causing the validation to run when selecting the enter manual address link from the address list screen, it found the (mostly) empty address in the cache that was being used to store the postcode to search on. So to fix, I have stored the postcode used for the search in the cache separate from the address.
Lots of tests were updated.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.