### PR TITLE
amend content on tell us about psc page

### DIFF
--- a/locales/cy/personWithSignificantControl.json
+++ b/locales/cy/personWithSignificantControl.json
@@ -10,9 +10,19 @@
         },
         "tellUsAboutPscPage": {
             "title": "WELSH - Tell us about people with significant control (PSCs)",
-            "pageInformation": "WELSH - We'll ask you whether the partnership will have any PSCs. If it will, you'll need to tell us about them.",
-            "moreThanOne": "WELSH - If the partnership has more than one PSC, you'll add them one at a time.",
-            "futureChanges": "WELSH - You'll need to file any future changes to PSCs on paper."
+            "whatWeAsk": "WELSH - We'll ask you if the partnership will have any PSCs on registration. If it will, you need to tell us about them.",
+            "addingMoreAfter": "WELSH - After the partnership is registered, you'll need to file a paper form if you need to add any more PSCs.",
+            "WhatIsPsc": "WELSH - What is a PSC?",
+            "psc": "WELSH - A person with significant control (PSC) is someone who owns or controls the partnership. They do this by meeting one or more conditions known as 'natures of control'.",
+            "includes": "WELSH - These include:",
+            "shareOfAssets": "WELSH - more than 25% share of assets",
+            "votingRights": "WELSH - more than 25% ownership of voting rights",
+            "rights": "WELSH - the right to appoint or remove management",
+            "influence": "WELSH - significant influence or control over the partnership",
+            "firmOrTrust": "WELSH - They can also be a PSC if they have significant control over a firm or trust that meets any of these natures of control.",
+            "pscType": "WELSH - A PSC can be an individual person, a relevant legal entity (RLE) or an other registrable person (ORP).",
+            "moreInformation": "WELSH - For more information, ",
+            "guidance": "WELSH - read the guidance on PSCs of Scottish limited partnerships (opens in new tab)."
         },
          "willThePartnershipHaveAnyPscPage": {
             "title": "WELSH - Will the partnership have any people with significant control (PSCs) on registration?",

--- a/locales/en/personWithSignificantControl.json
+++ b/locales/en/personWithSignificantControl.json
@@ -10,9 +10,19 @@
         },
         "tellUsAboutPscPage": {
             "title": "Tell us about people with significant control (PSCs)",
-            "pageInformation": "We'll ask you whether the partnership will have any PSCs. If it will, you'll need to tell us about them.",
-            "moreThanOne": "If the partnership has more than one PSC, you'll add them one at a time.",
-            "futureChanges": "You'll need to file any future changes to PSCs on paper."
+            "whatWeAsk": "We'll ask you if the partnership will have any PSCs on registration. If it will, you need to tell us about them.",
+            "addingMoreAfter": "After the partnership is registered, you'll need to file a paper form if you need to add any more PSCs.",
+            "WhatIsPsc": "What is a PSC?",
+            "psc": "A person with significant control (PSC) is someone who owns or controls the partnership. They do this by meeting one or more conditions known as 'natures of control'.",
+            "includes": "These include:",
+            "shareOfAssets": "more than 25% share of assets",
+            "votingRights": "more than 25% ownership of voting rights",
+            "rights": "the right to appoint or remove management",
+            "influence": "significant influence or control over the partnership",
+            "firmOrTrust": "They can also be a PSC if they have significant control over a firm or trust that meets any of these natures of control.",
+            "pscType": "A PSC can be an individual person, a relevant legal entity (RLE) or an other registrable person (ORP).",
+            "moreInformation": "For more information, ",
+            "guidance": "read the guidance on PSCs of Scottish limited partnerships (opens in new tab)."
         },
          "willThePartnershipHaveAnyPscPage": {
             "title": "Will the partnership have any people with significant control (PSCs) on registration?",

--- a/src/views/tell-us-about-people-with-significant-control.njk
+++ b/src/views/tell-us-about-people-with-significant-control.njk
@@ -10,11 +10,30 @@
  
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
-        <p class="govuk-body">{{ i18n.personWithSignificantControl.tellUsAboutPscPage.pageInformation }}</p>
+        <p class="govuk-body">{{ i18n.personWithSignificantControl.tellUsAboutPscPage.whatWeAsk }}</p>
+        <p class="govuk-body">{{ i18n.personWithSignificantControl.tellUsAboutPscPage.addingMoreAfter }}</p>
 
-        <p class="govuk-body">{{ i18n.personWithSignificantControl.tellUsAboutPscPage.moreThanOne }}</p>
+        {{ govukDetails({
+          summaryText: i18n.personWithSignificantControl.tellUsAboutPscPage.WhatIsPsc,
+          html: 
+            '<p>' + i18n.personWithSignificantControl.tellUsAboutPscPage.psc | escape + '</p>' 
+            + '<p>' + i18n.personWithSignificantControl.tellUsAboutPscPage.includes | escape + '</p>'
+              + '<ul>'
+                  + '<li>' + i18n.personWithSignificantControl.tellUsAboutPscPage.shareOfAssets | escape + '</li>'
+                  + '<li>' + i18n.personWithSignificantControl.tellUsAboutPscPage.votingRights | escape + '</li>'
+                  + '<li>' + i18n.personWithSignificantControl.tellUsAboutPscPage.rights | escape + '</li>'
+                  + '<li>' + i18n.personWithSignificantControl.tellUsAboutPscPage.influence | escape + '</li>'
+              + '</ul>'
+              + '<p>' + i18n.personWithSignificantControl.tellUsAboutPscPage.firmOrTrust | escape + '</p>'
+              + '<p>' + i18n.personWithSignificantControl.tellUsAboutPscPage.pscType | escape + '</p>'
+              + '<p>' + i18n.personWithSignificantControl.tellUsAboutPscPage.moreInformation | escape 
+                + '<a class="govuk-link govuk-link--no-visited-state govuk-body-m" rel="noreferrer noopener" target="_blank" href="' 
+                  + 'https://www.gov.uk/guidance/people-with-significant-control-pscs#registering-your-psc-information' + '">' 
+                  + i18n.personWithSignificantControl.tellUsAboutPscPage.guidance 
+                + '</a>' 
+              + '</p>'
+        }) }}
 
-        <p class="govuk-body">{{ i18n.personWithSignificantControl.tellUsAboutPscPage.futureChanges }}</p>
       
         <button class="govuk-button" data-event-id="continue" onClick="location.href='{{ props.nextUrl }}'">{{ i18n.buttons.continue }}</button>
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2046


### Change description
This pull request enhances the "Tell us about people with significant control (PSC)" page by providing more detailed and user-friendly information about PSCs in both English and Welsh. It updates the content in the translation files and significantly improves the user interface to include an expandable details section explaining what a PSC is, the conditions that define a PSC, and where to find further guidance.

Content and translation improvements:

* Expanded and clarified the English and Welsh translation files (`personWithSignificantControl.json`) to include detailed explanations of what a PSC is, the conditions that define a PSC, types of PSCs, and guidance links. [[1]](diffhunk://#diff-a13359fd5b2b43ca41f5dcc91c0ff5e23b3ef77edb46a72a4c7e2cbea11775ecL13-R25) [[2]](diffhunk://#diff-08a8f668ae4906e2061dd00722686e4f590256fc42429077025a63ff9894e9daL13-R25)

User interface enhancements:

* Updated the `tell-us-about-people-with-significant-control.njk` template to:
  - Replace previous brief paragraphs with new, clearer content about PSCs.
  - Add a GOV.UK details component that provides an accessible, expandable section explaining PSCs, including a bulleted list of the main conditions and a direct link to official guidance.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.