### PR TITLE
LP-2072 Fix stale PartnerPersonValidator delegate causing validation errors on cease date page

### DIFF
--- a/src/domain/validator/PartnerValidator.ts
+++ b/src/domain/validator/PartnerValidator.ts
@@ -12,6 +12,8 @@ export default class PartnerValidator {
 
     // data.partnerType and data.partnerEntityType are set/defined on the pageRouting data
 
+    this.delegate = null;
+
     if (data.partnerEntityType === PartnerEntityType.person) {
       this.delegate = new PartnerPersonValidator().set(data, i18n);
     }

--- a/src/presentation/test/unit/domain/partner-validator.spec.ts
+++ b/src/presentation/test/unit/domain/partner-validator.spec.ts
@@ -1,0 +1,67 @@
+import PartnerValidator from "../../../../domain/validator/PartnerValidator";
+import { PartnerEntityType } from "../../../../domain/types";
+
+const mockI18n = {
+  errorMessages: {
+    partners: {
+      addPartner: {
+        firstNameMissing: "Enter the first name",
+        lastNameMissing: "Enter the last name",
+        previousNameNotSelected: "Select yes if the person has used another name",
+        formerNamesMissing: "Enter former names",
+        nationality1Missing: "Enter nationality",
+        disqualificationStatementMissingGeneralPartner: "You must confirm they are not disqualified"
+      }
+    },
+    dateOfBirth: {
+      dayMissing: "Enter a day",
+      monthMissing: "Enter a month",
+      yearMissing: "Enter a year",
+      dateMissing: "Enter a date of birth",
+      invalid: "Enter a real date of birth",
+      future: "Date of birth must be in the past"
+    }
+  }
+};
+
+describe("PartnerValidator", () => {
+  describe("delegate reset between requests", () => {
+    it("should not retain the PartnerPersonValidator delegate from a previous request when partnerEntityType is not set", () => {
+      const validator = new PartnerValidator();
+
+      // Simulate first request: adding a general partner person (sets delegate)
+      validator.set({ partnerEntityType: PartnerEntityType.person, forename: "John", surname: "Doe" }, mockI18n);
+
+      // Simulate second request: cease date page (no partnerEntityType — delegate must be cleared)
+      const errors = validator.set({
+        "cease_date-day": "01",
+        "cease_date-month": "01",
+        "cease_date-year": "2025",
+        remove_confirmation_checked: "true"
+      }, mockI18n).runValidation();
+
+      expect(errors.hasErrors()).toBe(false);
+    });
+
+    it("should run PartnerPersonValidator when partnerEntityType is person", () => {
+      const validator = new PartnerValidator();
+
+      // Missing required person fields — should produce validation errors
+      const errors = validator.set({ partnerEntityType: PartnerEntityType.person }, mockI18n).runValidation();
+
+      expect(errors.hasErrors()).toBe(true);
+    });
+
+    it("should not run validation when partnerEntityType is undefined", () => {
+      const validator = new PartnerValidator();
+
+      const errors = validator.set({
+        "cease_date-day": "01",
+        "cease_date-month": "01",
+        "cease_date-year": "2025"
+      }, mockI18n).runValidation();
+
+      expect(errors.hasErrors()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-2072

### Change description

LP-2072 Fix stale PartnerPersonValidator delegate causing validation errors on cease date page


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.