### PR TITLE
LP-1473: Capital contribution vaidation fix to enable expected behaviour

### DIFF
--- a/src/application/service/LimitedPartnerService.ts
+++ b/src/application/service/LimitedPartnerService.ts
@@ -4,7 +4,7 @@ import { logger } from "../../utils";
 import UIErrors from "../../domain/entities/UIErrors";
 import { extractAPIErrors, incompletePartnerErrorList } from "./utils";
 import { Tokens } from "../../domain/types";
-import { capitalContributionValidation } from "./utils/capitalContributionValidation";
+import { capitalContributionValidation, isCapitalContributionApplicable } from "./utils/capitalContributionValidation";
 
 class LimitedPartnerService {
   i18n: any;
@@ -24,7 +24,7 @@ class LimitedPartnerService {
     errors?: UIErrors;
   }> {
     try {
-      if (data.contribution_currency_type || data.contribution_currency_value || data.contribution_sub_types) {
+      if (isCapitalContributionApplicable(data)) {
         capitalContributionValidation(data, this.i18n);
       }
 
@@ -93,7 +93,7 @@ class LimitedPartnerService {
     errors?: UIErrors;
   }> {
     try {
-      if (data.contribution_currency_type || data.contribution_currency_value || data.contribution_sub_types) {
+      if (isCapitalContributionApplicable(data)) {
         capitalContributionValidation(data, this.i18n);
       }
 

--- a/src/application/service/utils/capitalContributionValidation.ts
+++ b/src/application/service/utils/capitalContributionValidation.ts
@@ -1,9 +1,26 @@
+import { PartnershipType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+
 import UIErrors from "../../../domain/entities/UIErrors";
 import { symbols } from "./currencies";
 
 // CHIPS enforces a maximum of 10 digits in total with up to 2 decimal places
 // (CheckMaxDecimalValueRule precision=10, scale=2), giving a maximum value of 99999999.99.
 const MAX_DIGITS = 10;
+
+// The capital contribution section is only shown for LP/SLP partnerships in the
+// registration and post-transition journeys (see capital-contribution.njk). It must
+// be validated whenever that section is shown - including when every field is left
+// blank - otherwise the "required" errors fall through to the backend, which returns
+// them unlocalised (English). See LP-1473.
+const CAPITAL_CONTRIBUTION_PARTNERSHIP_TYPES: string[] = [PartnershipType.LP, PartnershipType.SLP];
+
+const isCapitalContributionApplicable = (data: Record<string, any>): boolean => {
+  const journeyTypes = data?.journeyTypes ?? {};
+  const isCapitalContributionJourney = Boolean(journeyTypes.isRegistration || journeyTypes.isPostTransition);
+  const isCapitalContributionPartnershipType = CAPITAL_CONTRIBUTION_PARTNERSHIP_TYPES.includes(data?.partnershipType);
+
+  return isCapitalContributionJourney && isCapitalContributionPartnershipType;
+};
 
 const capitalContributionValidation = (data: Record<string, string | string[]>, i18n: any): void => {
   const uiErrors = new UIErrors();
@@ -69,4 +86,4 @@ const hasComma = (str: string): boolean => {
   return str.includes(",");
 };
 
-export { capitalContributionValidation };
+export { capitalContributionValidation, isCapitalContributionApplicable };

--- a/src/presentation/test/integration/registration/limitedPartner/add-limited-partner-person.test.ts
+++ b/src/presentation/test/integration/registration/limitedPartner/add-limited-partner-person.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import enTranslationText from "../../../../../../locales/en/translations.json";
 import cyTranslationText from "../../../../../../locales/cy/translations.json";
+import cyErrorsText from "../../../../../../locales/cy/errors.json";
 import app from "../../app";
 import LimitedPartnershipBuilder from "../../../builder/LimitedPartnershipBuilder";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
@@ -222,6 +223,40 @@ describe("Add Limited Partner Person Page", () => {
       expect(res.text).toContain('id="previous_name-2" name="previous_name" type="radio" value="false" checked');
       expect(res.text).toContain("Mongolian");
       expect(res.text).toContain("Uzbek");
+    });
+
+    it("should show localised capital contribution errors when the section is left blank for an LP (LP-1473)", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().withPartnershipType(PartnershipType.LP).build();
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      setLocalesEnabled(true);
+
+      const res = await request(app)
+        .post(URL + "?lang=cy")
+        .send({
+          pageType: RegistrationPageType.addLimitedPartnerPerson,
+          partnershipType: PartnershipType.LP,
+          forename: "test"
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(cyErrorsText.errorMessages.capitalContribution.currencyRequired);
+      expect(res.text).toContain(cyErrorsText.errorMessages.capitalContribution.valueRequired);
+      expect(res.text).toContain(cyErrorsText.errorMessages.capitalContribution.atLeastOneType);
+    });
+
+    it("should not require capital contribution when the section is not shown (PFLP)", async () => {
+      const limitedPartnership = new LimitedPartnershipBuilder().withPartnershipType(PartnershipType.PFLP).build();
+      appDevDependencies.limitedPartnershipGateway.feedLimitedPartnerships([limitedPartnership]);
+
+      const res = await request(app).post(URL).send({
+        pageType: RegistrationPageType.addLimitedPartnerPerson,
+        partnershipType: PartnershipType.PFLP,
+        forename: "test"
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
     });
 
     it.each(["", "   ", undefined])(

--- a/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
+++ b/src/presentation/test/unit/registration/capital-contribution-validation.spec.ts
@@ -1,5 +1,8 @@
 import UIErrors from "../../../../domain/entities/UIErrors";
-import { capitalContributionValidation } from "../../../../application/service/utils/capitalContributionValidation";
+import {
+  capitalContributionValidation,
+  isCapitalContributionApplicable
+} from "../../../../application/service/utils/capitalContributionValidation";
 
 import i18nErrorsEn from "../../../../../locales/en/errors.json";
 import i18nErrorsCy from "../../../../../locales/cy/errors.json";
@@ -126,5 +129,22 @@ describe("Gateway capital contribition validation test suite", () => {
         })
       );
     });
+  });
+});
+
+describe("isCapitalContributionApplicable", () => {
+  it.each([
+    ["registration LP", { journeyTypes: { isRegistration: true }, partnershipType: "LP" }, true],
+    ["registration SLP", { journeyTypes: { isRegistration: true }, partnershipType: "SLP" }, true],
+    ["post-transition LP", { journeyTypes: { isPostTransition: true }, partnershipType: "LP" }, true],
+    ["post-transition SLP", { journeyTypes: { isPostTransition: true }, partnershipType: "SLP" }, true],
+    ["registration PFLP", { journeyTypes: { isRegistration: true }, partnershipType: "PFLP" }, false],
+    ["registration SPFLP", { journeyTypes: { isRegistration: true }, partnershipType: "SPFLP" }, false],
+    ["transition LP (section not shown)", { journeyTypes: { isTransition: true }, partnershipType: "LP" }, false],
+    ["missing partnership type", { journeyTypes: { isRegistration: true } }, false],
+    ["missing journey types", { partnershipType: "LP" }, false],
+    ["empty data", {}, false]
+  ])("returns %s -> %s", (_description, data, expected) => {
+    expect(isCapitalContributionApplicable(data)).toBe(expected);
   });
 });

--- a/src/views/includes/capital-contribution.njk
+++ b/src/views/includes/capital-contribution.njk
@@ -1,5 +1,9 @@
 {% if (partnershipType == "LP") or (partnershipType == "SLP") %}
 
+  {# Lets the server know the capital contribution section was shown so it can validate
+     it even when every field is left blank (LP-1473). #}
+  <input type="hidden" name="partnershipType" value="{{ partnershipType }}">
+
   <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
   <h2 class="govuk-heading-m">{{ i18n.capitalContribution.title}}</h2>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1473


### Change description

Capital contribution vaidation fix to enable expected behaviour when capital contribution fields are not entered

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.