### PR TITLE
LP-1529: Preserve Welsh language on payment resume

### DIFF
--- a/src/presentation/controller/global/Controller.ts
+++ b/src/presentation/controller/global/Controller.ts
@@ -291,7 +291,7 @@ class GlobalController extends AbstractController {
       const { journey, resumeUrl } = getJourneyAndUrl(transaction);
 
       if (this.isPendingPayment(transaction)) {
-        return this.handlePendingPayment(response, tokens, ids, journey);
+        return this.handlePendingPayment(request, response, tokens, ids, journey);
       }
 
       const resumePage = super.insertIdsInUrl(resumeUrl, { ...ids, companyId: transaction.companyNumber ?? "" });
@@ -305,10 +305,10 @@ class GlobalController extends AbstractController {
     return transaction.status === TransactionStatus.closedPendingPayment;
   }
 
-  private async handlePendingPayment(response: Response, tokens: Tokens, ids: Ids, journey: string) {
+  private async handlePendingPayment(request: Request, response: Response, tokens: Tokens, ids: Ids, journey: string) {
     const startPaymentSessionUrl = PAYMENTS_API_URL + "/payments";
     const paymentReturnUrl = `${CHS_URL}${PAYMENT_RESPONSE_URL}`.replace(JOURNEY_TYPE_PARAM, journey);
-    const paymentReturnUrlWithIds = super.insertIdsInUrl(paymentReturnUrl, ids);
+    const paymentReturnUrlWithIds = super.insertIdsInUrl(paymentReturnUrl, ids, request.url);
     const redirectToPaymentServiceUrl = await this.paymentService.startPaymentSession(
       tokens,
       startPaymentSessionUrl,

--- a/src/presentation/test/integration/global/resume.test.ts
+++ b/src/presentation/test/integration/global/resume.test.ts
@@ -169,6 +169,46 @@ describe("Resume a journey", () => {
   });
 
   it.each([
+    {
+      filingMode: TransactionKind.registration,
+      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
+        JOURNEY_TYPE_PARAM,
+        Journey.registration
+      )
+    },
+    {
+      filingMode: TransactionKind.transition,
+      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
+        JOURNEY_TYPE_PARAM,
+        Journey.transition
+      )
+    }
+  ])(
+    "should preserve the language when resuming a pay now $filingMode journey in Welsh",
+    async ({ filingMode, expectedPaymentReturnUrl }) => {
+      const transaction = new TransactionBuilder()
+        .withFilingMode(filingMode)
+        .withCompanyName("Test Company")
+        .withCompanyNumber("LP123456")
+        .withStatus(TransactionStatus.closedPendingPayment)
+        .build();
+
+      appDevDependencies.transactionGateway.feedTransactions([transaction]);
+
+      const res = await request(app).get(`${RESUME_REGISTRATION_OR_TRANSITION_URL}?lang=cy`);
+
+      expect(res.status).toEqual(302);
+      expect(res.headers.location).toEqual(appDevDependencies.paymentGateway.payment.links.journey);
+
+      // The lang param must be carried into the payment return url so the
+      // payment success/failure screens resume in Welsh
+      expect(appDevDependencies.paymentGateway.lastCreatePaymentRequest?.redirectUri).toEqual(
+        `${expectedPaymentReturnUrl}?lang=cy`
+      );
+    }
+  );
+
+  it.each([
     { filingMode: undefined as unknown as string, description: "undefined" },
     { filingMode: "", description: "empty string" },
     { filingMode: "invalid", description: "invalid string" }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1529

### Change description

When a filing journey was carried out in Welsh and the user resumed a pending payment, the payment success/failure screens returned in English instead of Welsh.

On resume, `handlePendingPayment` builds the payment return URL (the `redirectUri` GOV.UK Pay redirects back to after payment) without carrying the language preference. This change passes `request.url` into `insertIdsInUrl`, so the request's query string (e.g. `lang=cy`) is propagated onto the return URL. When the user is redirected back after payment, the URL carries `lang=cy` and the success/failure screens render in Welsh.

Both the success and failure screens use the same return URL, so a single change covers both outcomes.

Added integration tests covering the `registration` and `transition` journeys, asserting the `lang=cy` param is carried into the payment return URL.

Note: end-to-end behaviour depends on the resume request itself carrying `lang=cy`; this should be confirmed by manual testing on CIDev for both successful and unsuccessful payments.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile (N/A - no UI changes)
- [ ] UI changes meet accessibility criteria (N/A - no UI changes)
