### PR TITLE
[lp-2059] : add dynamic text based on PSC type

### DIFF
--- a/src/presentation/test/integration/registration/personWithSignificantControl/add-nature-of-control.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/add-nature-of-control.test.ts
@@ -1,5 +1,8 @@
 import request from "supertest";
-import { NatureOfControlType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
+import {
+  NatureOfControlType,
+  PersonWithSignificantControlType
+} from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 
 import enGeneralTranslationText from "../../../../../../locales/en/translations.json";
 import cyGeneralTranslationText from "../../../../../../locales/cy/translations.json";
@@ -74,6 +77,46 @@ describe("Add Nature of Control Page", () => {
 
         const backUrl = getUrl(WHICH_TYPE_OF_NATURE_OF_CONTROL_INDIVIDUAL_PERSON_URL);
         expect(res.text).toContain(backUrl);
+      }
+    );
+
+    it.each([
+      [PersonWithSignificantControlType.INDIVIDUAL_PERSON, "individual"],
+      [PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY, "RLE"],
+      [PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON, "ORP"]
+    ])(
+      "should load the add nature of control page with text depending of the PSC type - %s",
+      async (type: string, expectedText: string) => {
+        const personWithSignificantControlBuilder = new PersonWithSignificantControlBuilder().withId(
+          appDevDependencies.personWithSignificantControlGateway.personWithSignificantControlId
+        );
+
+        if (type === PersonWithSignificantControlType.INDIVIDUAL_PERSON) {
+          personWithSignificantControlBuilder.isIndividualPerson();
+        } else if (type === PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY) {
+          personWithSignificantControlBuilder.isRelevantLegalEntity();
+        } else if (type === PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON) {
+          personWithSignificantControlBuilder.isOtherRegistrablePerson();
+        }
+
+        const personWithSignificantControl = personWithSignificantControlBuilder.build();
+
+        appDevDependencies.personWithSignificantControlGateway.feedPersonsWithSignificantControl([personWithSignificantControl]);
+
+        const URL = getUrl(ADD_NATURE_OF_CONTROL_INDIVIDUAL_URL);
+
+        const res = await request(app).get(URL);
+
+        expect(res.status).toBe(200);
+
+        expect(res.text).toContain(
+          toEscapedHtml(
+            enPersonWithSignificantControlTranslationText.personWithSignificantControl.addNatureOfControlPage.individual.title.replace(
+              "individual",
+              expectedText
+            )
+          )
+        );
       }
     );
 

--- a/src/views/add-nature-of-control-individual.njk
+++ b/src/views/add-nature-of-control-individual.njk
@@ -1,9 +1,20 @@
 {% extends "layout.njk" %}
 
-{% set pageTitle = i18n.personWithSignificantControl.addNatureOfControlPage.individual.title %}
 {% set publicRegisterInformationLine1 = i18n.personWithSignificantControl.addNatureOfControlPage.publicRegisterInformationLine1 %}
-{% set shareOfAssetsHint = i18n.personWithSignificantControl.addNatureOfControlPage.individual.shareOfAssetsHint %}
-{% set votingRightsHint = i18n.personWithSignificantControl.addNatureOfControlPage.individual.votingRightsHint %}
+
+{% set pscType = 'individual' %}
+{% if props.data.personWithSignificantControl.data.type == "RELEVANT_LEGAL_ENTITY" %}
+    {% set pscType = 'RLE' %}
+{% elif props.data.personWithSignificantControl.data.type == "OTHER_REGISTRABLE_PERSON" %}
+    {% set pscType = 'ORP' %}
+{% endif %}
+
+{% set pageTitle = i18n.personWithSignificantControl.addNatureOfControlPage.individual.title | replace("individual", pscType) %}
+{% set pageTitleHint = i18n.personWithSignificantControl.addNatureOfControlPage.individual.titleHint | replace("individual", pscType) %}
+{% set shareOfAssetsHint = i18n.personWithSignificantControl.addNatureOfControlPage.individual.shareOfAssetsHint | replace("individual", pscType)  %}
+{% set votingRightsHint = i18n.personWithSignificantControl.addNatureOfControlPage.individual.votingRightsHint | replace("individual", pscType)  %}
+{% set ownershipCheckboxText = i18n.personWithSignificantControl.addNatureOfControlPage.individual.ownershipCheckboxText | replace("individual", pscType)  %}
+{% set sigInfluenceCheckboxText = i18n.personWithSignificantControl.addNatureOfControlPage.individual.sigInfluenceCheckboxText | replace("individual", pscType)  %}
 
 {% set natureOfControl = (props.data.personWithSignificantControl.data.natures_of_control or []) | selectattr("type", "equalto", "INDIVIDUAL") | first %}
 
@@ -16,7 +27,7 @@
             {% include "pages/personWithSignificantControl/person-with-significant-control-name.njk" %}
             
             <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ pageTitle }}</h1>
-            <p class="govuk-hint govuk-!-margin-top-0">{{ i18n.personWithSignificantControl.addNatureOfControlPage.individual.titleHint }}</p>
+            <p class="govuk-hint govuk-!-margin-top-0">{{ pageTitleHint }}</p>
 
             <form class="form" method="post">
                 <input type="hidden" name="pageType" value={{ props.pageType }}> 

--- a/src/views/pages/natureOfControl/nature-of-control-radio.njk
+++ b/src/views/pages/natureOfControl/nature-of-control-radio.njk
@@ -74,7 +74,7 @@
     items: [
     {
         value: "true",
-        text: translationText.individual.ownershipCheckboxText,
+        text: ownershipCheckboxText,
         checked: natureOfControl.right_to_appointment_and_remove
     }
     ]
@@ -95,7 +95,7 @@
     items: [
     {
         value: "true",
-        text: translationText.individual.sigInfluenceCheckboxText,
+        text: sigInfluenceCheckboxText,
         checked: natureOfControl.significant_influence_control
     }
     ]


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2059
https://companieshouse.atlassian.net/browse/LP-2060

### Change description
add dynamic text based on PSC type

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.