### PR TITLE
LP-1529: Add middleware to handle language between requests

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -13,7 +13,7 @@ import { setCeaseDateSection, setDateEffectiveFromSection, setDateOfBirthSection
 import { setCountriesDropdown } from "../utils/countries";
 import { setNationalitiesDropdown } from "../utils/nationalities";
 import * as config from "./constants";
-import { acspAuthentication, authentication, localisationMiddleware, trailingSlashMiddleware } from "../middlewares";
+import { acspAuthentication, authentication, languageMiddleware, localisationMiddleware, trailingSlashMiddleware } from "../middlewares";
 import { serviceAvailabilityMiddleware } from "../middlewares/service-availability.middleware";
 import { journeyDetectionMiddleware } from "../middlewares/journey.detection.middleware";
 import { TRANSITION_START_URL } from "../presentation/controller/transition/url";
@@ -91,6 +91,11 @@ export const appConfig = (app: express.Application) => {
   const sessionStore = new SessionStore(new Redis(`redis://${config.CACHE_SERVER}`));
 
   app.use(config.allPathsExceptHealthcheck, SessionMiddleware(cookieConfig, sessionStore));
+
+  // persist the selected language on the session so it can be recovered when
+  // the app is re-entered without a lang query param (e.g. resuming a payment
+  // from the "Your filings" page) - must run after SessionMiddleware
+  app.use(config.allPathsExceptHealthcheck, languageMiddleware);
 
   // csrf middleware
   const csrfProtectionMiddleware = CsrfProtectionMiddleware({

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -80,7 +80,6 @@ export const appConfig = (app: express.Application) => {
   app.use(trailingSlashMiddleware);
   app.use(serviceAvailabilityMiddleware);
   app.use(config.allPathsExceptHealthcheck, journeyDetectionMiddleware);
-  app.use(config.allPathsExceptHealthcheck, localisationMiddleware);
 
   const cookieConfig = {
     cookieName: "__SID",
@@ -96,6 +95,12 @@ export const appConfig = (app: express.Application) => {
   // the app is re-entered without a lang query param (e.g. resuming a payment
   // from the "Your filings" page) - must run after SessionMiddleware
   app.use(config.allPathsExceptHealthcheck, languageMiddleware);
+
+  // localisation must run after SessionMiddleware/languageMiddleware so it can
+  // fall back to the language persisted on the session when a request carries
+  // no (valid) lang query param - e.g. the payment success/failure/confirmation
+  // screens reached after resuming a Welsh payment (LP-1529)
+  app.use(config.allPathsExceptHealthcheck, localisationMiddleware);
 
   // csrf middleware
   const csrfProtectionMiddleware = CsrfProtectionMiddleware({

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { CsrfError, InvalidAcspNumberError } from "@companieshouse/web-security-node";
 
-import { getLoggedInUserEmail, logger } from "../utils";
+import { addLangToUrl, getLoggedInUserEmail, logger } from "../utils";
 import * as config from "../config/constants";
 import { PARTNERSHIP_TYPE_URL } from "../presentation/controller/registration/url";
 import { NOT_ELIGIBLE_URL } from "../presentation/controller/global/url";
@@ -49,7 +49,7 @@ const invalidAcspNumberErrorHandler = (err: Error, req: Request, res: Response, 
   logger.infoRequest(req, `Invalid ACSP error received - ${err.message}`);
   let URL = NOT_ELIGIBLE_URL;
   if (req.session?.data?.lang) {
-    URL = NOT_ELIGIBLE_URL + `?lang=${req.session.data.lang}`;
+    URL = addLangToUrl(NOT_ELIGIBLE_URL, req.session.data.lang);
   };
 
   return res.redirect(URL);

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -2,6 +2,7 @@ export * from "./acsp-authentication.middleware";
 export * from "./authentication.middleware";
 export * from "./error.middleware";
 export * from "./localisation.middleware";
+export * from "./language.middleware";
 export * from "./company-authentication.middleware";
 export * from "./trailing-slash.middleware";
 export * from "./transition-filing.middleware";

--- a/src/middlewares/language.middleware.ts
+++ b/src/middlewares/language.middleware.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from "express";
+import { selectLang } from "../utils";
+
+/**
+ * Persists the selected language on the session whenever a request carries a
+ * `lang` query param.
+ *
+ * The `lang` query param is the only source of language for a request
+ * (see localisationMiddleware), and it is lost when the app is re-entered from
+ * an external page - e.g. resuming a pending payment from the "Your filings"
+ * page, whose resume link carries no `lang`. Storing the choice on the session
+ * lets those flows recover it so the payment success/failure screens stay in
+ * Welsh when the journey was completed in Welsh (LP-1529).
+ *
+ * Must be registered after SessionMiddleware so that `req.session` is available.
+ */
+export const languageMiddleware = (req: Request, _res: Response, next: NextFunction): void => {
+  if (req.session && req.query.lang) {
+    req.session.setLanguage(selectLang(req.query.lang));
+  }
+
+  next();
+};

--- a/src/middlewares/language.middleware.ts
+++ b/src/middlewares/language.middleware.ts
@@ -5,12 +5,12 @@ import { selectLang } from "../utils";
  * Persists the selected language on the session whenever a request carries a
  * `lang` query param.
  *
- * The `lang` query param is the only source of language for a request
- * (see localisationMiddleware), and it is lost when the app is re-entered from
- * an external page - e.g. resuming a pending payment from the "Your filings"
- * page, whose resume link carries no `lang`. Storing the choice on the session
- * lets those flows recover it so the payment success/failure screens stay in
- * Welsh when the journey was completed in Welsh (LP-1529).
+ * A request's language normally travels in the `lang` query param, but that is
+ * lost when the app is re-entered from an external page - e.g. resuming a
+ * pending payment from the "Your filings" page, whose resume link carries no
+ * `lang`. Storing the choice on the session lets `localisationMiddleware` fall
+ * back to it, so the payment success/failure/confirmation screens stay in Welsh
+ * when the journey was completed in Welsh (LP-1529).
  *
  * Must be registered after SessionMiddleware so that `req.session` is available.
  */

--- a/src/middlewares/localisation.middleware.ts
+++ b/src/middlewares/localisation.middleware.ts
@@ -10,7 +10,16 @@ export const localisationMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
-  const lang = selectLang(req.query.lang);
+  // An explicit, valid `lang` query param always wins so a user can switch
+  // language mid-journey. Otherwise fall back to the language persisted on the
+  // session, so a page re-entered without a lang param - e.g. the payment
+  // success/failure/confirmation screens after resuming a Welsh payment - still
+  // renders in the language the journey was started in (LP-1529).
+  const langSource =
+    req.query.lang === "en" || req.query.lang === "cy"
+      ? req.query.lang
+      : req.session?.getLanguage?.();
+  const lang = selectLang(langSource);
   const localesService = getLocalesService();
   const localisationProps = getLocalisationProperties(localesService, lang);
 

--- a/src/presentation/controller/AbstractController.ts
+++ b/src/presentation/controller/AbstractController.ts
@@ -160,20 +160,18 @@ abstract class AbstractController {
   }
 
   private addLangToUrls(currentUrl: string, pageRouting: PageRouting): PageRouting {
-    const currentUrlParams = new URLSearchParams(new URL(`http://${currentUrl}`)?.search);
+    const lang = this.getLangFromUrl(currentUrl);
 
-    if (currentUrlParams.has("lang")) {
-      const lang = currentUrlParams.get("lang") ?? "";
-
-      return {
-        ...pageRouting,
-        previousUrl: this.addOrAppendQueryParam(pageRouting.previousUrl, "lang", lang),
-        currentUrl: this.addOrAppendQueryParam(pageRouting.currentUrl, "lang", lang),
-        nextUrl: this.addOrAppendQueryParam(pageRouting.nextUrl, "lang", lang)
-      };
+    if (lang === null) {
+      return pageRouting;
     }
 
-    return pageRouting;
+    return {
+      ...pageRouting,
+      previousUrl: this.addOrAppendQueryParam(pageRouting.previousUrl, "lang", lang),
+      currentUrl: this.addOrAppendQueryParam(pageRouting.currentUrl, "lang", lang),
+      nextUrl: this.addOrAppendQueryParam(pageRouting.nextUrl, "lang", lang)
+    };
   }
 
   protected extractPageTypeOrThrowError(request: Request, pageTypeEnum: object) {
@@ -224,6 +222,10 @@ abstract class AbstractController {
     }
 
     return PARTNERSHIP_TYPE_URL;
+  }
+
+  protected getLangFromUrl(url: string): string | null {
+    return new URLSearchParams(new URL(`http://${url}`).search).get("lang");
   }
 
   protected addOrAppendQueryParam(url: string, key: string, value: string): string {

--- a/src/presentation/controller/AbstractController.ts
+++ b/src/presentation/controller/AbstractController.ts
@@ -163,13 +163,13 @@ abstract class AbstractController {
     const currentUrlParams = new URLSearchParams(new URL(`http://${currentUrl}`)?.search);
 
     if (currentUrlParams.has("lang")) {
-      const langQuery = `?lang=${currentUrlParams.get("lang")}`;
+      const lang = currentUrlParams.get("lang") ?? "";
 
       return {
         ...pageRouting,
-        previousUrl: `${pageRouting.previousUrl}${langQuery}`,
-        currentUrl: `${pageRouting.currentUrl}${langQuery}`,
-        nextUrl: `${pageRouting.nextUrl}${langQuery}`
+        previousUrl: this.addOrAppendQueryParam(pageRouting.previousUrl, "lang", lang),
+        currentUrl: this.addOrAppendQueryParam(pageRouting.currentUrl, "lang", lang),
+        nextUrl: this.addOrAppendQueryParam(pageRouting.nextUrl, "lang", lang)
       };
     }
 

--- a/src/presentation/controller/global/Controller.ts
+++ b/src/presentation/controller/global/Controller.ts
@@ -15,7 +15,7 @@ import {
   JOURNEY_QUERY_PARAM
 } from "../../../config/constants";
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
-import { getJourneyTypes, getLoggedInUserEmail, logger } from "../../../utils";
+import { addLangToUrl, getJourneyTypes, getLoggedInUserEmail, logger } from "../../../utils";
 import PaymentService from "../../../application/service/PaymentService";
 import { CONFIRMATION_URL, PAYMENT_FAILED_URL, PAYMENT_RESPONSE_URL, CONFIRMATION_POST_TRANSITION_URL } from "./url";
 import TransactionService from "../../../application/service/TransactionService";
@@ -308,7 +308,10 @@ class GlobalController extends AbstractController {
   private async handlePendingPayment(request: Request, response: Response, tokens: Tokens, ids: Ids, journey: string) {
     const startPaymentSessionUrl = PAYMENTS_API_URL + "/payments";
     const paymentReturnUrl = `${CHS_URL}${PAYMENT_RESPONSE_URL}`.replace(JOURNEY_TYPE_PARAM, journey);
-    const paymentReturnUrlWithIds = super.insertIdsInUrl(paymentReturnUrl, ids, request.url);
+    const paymentReturnUrlWithIds = this.appendSessionLanguageIfMissing(
+      request,
+      super.insertIdsInUrl(paymentReturnUrl, ids, request.url)
+    );
     const redirectToPaymentServiceUrl = await this.paymentService.startPaymentSession(
       tokens,
       startPaymentSessionUrl,
@@ -316,6 +319,19 @@ class GlobalController extends AbstractController {
       ids.transactionId
     );
     return response.redirect(redirectToPaymentServiceUrl);
+  }
+
+  // When a Welsh journey is resumed from the "Your filings" page the resume
+  // request carries no lang query param, so insertIdsInUrl cannot propagate it.
+  // Fall back to the language stored on the session so the payment
+  // success/failure screens still resume in Welsh (LP-1529).
+  private appendSessionLanguageIfMissing(request: Request, url: string): string {
+    const hasLangParam = new URLSearchParams(url.split("?")[1] ?? "").has("lang");
+    if (hasLangParam) {
+      return url;
+    }
+
+    return addLangToUrl(url, request.session?.getLanguage?.());
   }
 }
 

--- a/src/presentation/controller/global/Controller.ts
+++ b/src/presentation/controller/global/Controller.ts
@@ -141,16 +141,10 @@ class GlobalController extends AbstractController {
     };
   }
 
-  private appendLangParamIfExists(request: Request, nextPageUrlWithJourneyAndIds: string) {
-    const currentUrlParams = new URLSearchParams(new URL(`http://${request.url}`)?.search);
+  private appendLangParamIfExists(request: Request, url: string): string {
+    const lang = this.getLangFromUrl(request.url);
 
-    if (currentUrlParams.has("lang")) {
-      const langParam = currentUrlParams.get("lang") ?? "";
-
-      nextPageUrlWithJourneyAndIds = this.addOrAppendQueryParam(nextPageUrlWithJourneyAndIds, "lang", langParam);
-    }
-
-    return nextPageUrlWithJourneyAndIds;
+    return lang !== null ? this.addOrAppendQueryParam(url, "lang", lang) : url;
   }
 
   getConfirmationPage() {

--- a/src/presentation/controller/global/Controller.ts
+++ b/src/presentation/controller/global/Controller.ts
@@ -15,7 +15,7 @@ import {
   JOURNEY_QUERY_PARAM
 } from "../../../config/constants";
 import LimitedPartnershipService from "../../../application/service/LimitedPartnershipService";
-import { addLangToUrl, getJourneyTypes, getLoggedInUserEmail, logger } from "../../../utils";
+import { getJourneyTypes, getLoggedInUserEmail, logger } from "../../../utils";
 import PaymentService from "../../../application/service/PaymentService";
 import { CONFIRMATION_URL, PAYMENT_FAILED_URL, PAYMENT_RESPONSE_URL, CONFIRMATION_POST_TRANSITION_URL } from "./url";
 import TransactionService from "../../../application/service/TransactionService";
@@ -145,9 +145,9 @@ class GlobalController extends AbstractController {
     const currentUrlParams = new URLSearchParams(new URL(`http://${request.url}`)?.search);
 
     if (currentUrlParams.has("lang")) {
-      const langParam = currentUrlParams.get("lang");
+      const langParam = currentUrlParams.get("lang") ?? "";
 
-      nextPageUrlWithJourneyAndIds = nextPageUrlWithJourneyAndIds + `?lang=${langParam}`;
+      nextPageUrlWithJourneyAndIds = this.addOrAppendQueryParam(nextPageUrlWithJourneyAndIds, "lang", langParam);
     }
 
     return nextPageUrlWithJourneyAndIds;
@@ -308,10 +308,7 @@ class GlobalController extends AbstractController {
   private async handlePendingPayment(request: Request, response: Response, tokens: Tokens, ids: Ids, journey: string) {
     const startPaymentSessionUrl = PAYMENTS_API_URL + "/payments";
     const paymentReturnUrl = `${CHS_URL}${PAYMENT_RESPONSE_URL}`.replace(JOURNEY_TYPE_PARAM, journey);
-    const paymentReturnUrlWithIds = this.appendSessionLanguageIfMissing(
-      request,
-      super.insertIdsInUrl(paymentReturnUrl, ids, request.url)
-    );
+    const paymentReturnUrlWithIds = super.insertIdsInUrl(paymentReturnUrl, ids, request.url);
     const redirectToPaymentServiceUrl = await this.paymentService.startPaymentSession(
       tokens,
       startPaymentSessionUrl,
@@ -319,19 +316,6 @@ class GlobalController extends AbstractController {
       ids.transactionId
     );
     return response.redirect(redirectToPaymentServiceUrl);
-  }
-
-  // When a Welsh journey is resumed from the "Your filings" page the resume
-  // request carries no lang query param, so insertIdsInUrl cannot propagate it.
-  // Fall back to the language stored on the session so the payment
-  // success/failure screens still resume in Welsh (LP-1529).
-  private appendSessionLanguageIfMissing(request: Request, url: string): string {
-    const hasLangParam = new URLSearchParams(url.split("?")[1] ?? "").has("lang");
-    if (hasLangParam) {
-      return url;
-    }
-
-    return addLangToUrl(url, request.session?.getLanguage?.());
   }
 }
 

--- a/src/presentation/test/integration/global/resume.test.ts
+++ b/src/presentation/test/integration/global/resume.test.ts
@@ -28,24 +28,6 @@ import {
   TERM_WITH_IDS_URL
 } from "presentation/controller/postTransition/url";
 
-// The global test setup stubs SessionMiddleware to a no-op that never sets
-// req.session. Override it here so a stored session language can be injected via
-// the x-session-lang header, exercising the payment-resume language fallback.
-jest.mock("@companieshouse/node-session-handler", () => {
-  const actual = jest.requireActual("@companieshouse/node-session-handler");
-  return {
-    ...actual,
-    SessionMiddleware: () => (req: any, _res: any, next: any) => {
-      const lang = req.headers["x-session-lang"];
-      if (lang) {
-        req.session = new actual.Session();
-        req.session.setLanguage(lang);
-      }
-      next();
-    }
-  };
-});
-
 describe("Resume a journey", () => {
   const RESUME_REGISTRATION_OR_TRANSITION_URL = getUrl(RESUME_JOURNEY_REGISTRATION_OR_TRANSITION_URL);
   const RESUME_POST_TRANSITION_GENERAL_PARTNER_URL = getUrl(RESUME_JOURNEY_POST_TRANSITION_GENERAL_PARTNER_URL);
@@ -220,46 +202,6 @@ describe("Resume a journey", () => {
 
       // The lang param must be carried into the payment return url so the
       // payment success/failure screens resume in Welsh
-      expect(appDevDependencies.paymentGateway.lastCreatePaymentRequest?.redirectUri).toEqual(
-        `${expectedPaymentReturnUrl}?lang=cy`
-      );
-    }
-  );
-
-  it.each([
-    {
-      filingMode: TransactionKind.registration,
-      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
-        JOURNEY_TYPE_PARAM,
-        Journey.registration
-      )
-    },
-    {
-      filingMode: TransactionKind.transition,
-      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
-        JOURNEY_TYPE_PARAM,
-        Journey.transition
-      )
-    }
-  ])(
-    "should preserve the language from the session when resuming a pay now $filingMode journey with no lang query param",
-    async ({ filingMode, expectedPaymentReturnUrl }) => {
-      const transaction = new TransactionBuilder()
-        .withFilingMode(filingMode)
-        .withCompanyName("Test Company")
-        .withCompanyNumber("LP123456")
-        .withStatus(TransactionStatus.closedPendingPayment)
-        .build();
-
-      appDevDependencies.transactionGateway.feedTransactions([transaction]);
-
-      // Resume link from the "Your filings" page carries no lang query param -
-      // the Welsh preference is recovered from the session instead (LP-1529)
-      const res = await request(app).get(RESUME_REGISTRATION_OR_TRANSITION_URL).set("x-session-lang", "cy");
-
-      expect(res.status).toEqual(302);
-      expect(res.headers.location).toEqual(appDevDependencies.paymentGateway.payment.links.journey);
-
       expect(appDevDependencies.paymentGateway.lastCreatePaymentRequest?.redirectUri).toEqual(
         `${expectedPaymentReturnUrl}?lang=cy`
       );

--- a/src/presentation/test/integration/global/resume.test.ts
+++ b/src/presentation/test/integration/global/resume.test.ts
@@ -28,6 +28,24 @@ import {
   TERM_WITH_IDS_URL
 } from "presentation/controller/postTransition/url";
 
+// The global test setup stubs SessionMiddleware to a no-op that never sets
+// req.session. Override it here so a stored session language can be injected via
+// the x-session-lang header, exercising the payment-resume language fallback.
+jest.mock("@companieshouse/node-session-handler", () => {
+  const actual = jest.requireActual("@companieshouse/node-session-handler");
+  return {
+    ...actual,
+    SessionMiddleware: () => (req: any, _res: any, next: any) => {
+      const lang = req.headers["x-session-lang"];
+      if (lang) {
+        req.session = new actual.Session();
+        req.session.setLanguage(lang);
+      }
+      next();
+    }
+  };
+});
+
 describe("Resume a journey", () => {
   const RESUME_REGISTRATION_OR_TRANSITION_URL = getUrl(RESUME_JOURNEY_REGISTRATION_OR_TRANSITION_URL);
   const RESUME_POST_TRANSITION_GENERAL_PARTNER_URL = getUrl(RESUME_JOURNEY_POST_TRANSITION_GENERAL_PARTNER_URL);
@@ -202,6 +220,46 @@ describe("Resume a journey", () => {
 
       // The lang param must be carried into the payment return url so the
       // payment success/failure screens resume in Welsh
+      expect(appDevDependencies.paymentGateway.lastCreatePaymentRequest?.redirectUri).toEqual(
+        `${expectedPaymentReturnUrl}?lang=cy`
+      );
+    }
+  );
+
+  it.each([
+    {
+      filingMode: TransactionKind.registration,
+      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
+        JOURNEY_TYPE_PARAM,
+        Journey.registration
+      )
+    },
+    {
+      filingMode: TransactionKind.transition,
+      expectedPaymentReturnUrl: getUrl(`${CHS_URL}${PAYMENT_RESPONSE_URL}`).replace(
+        JOURNEY_TYPE_PARAM,
+        Journey.transition
+      )
+    }
+  ])(
+    "should preserve the language from the session when resuming a pay now $filingMode journey with no lang query param",
+    async ({ filingMode, expectedPaymentReturnUrl }) => {
+      const transaction = new TransactionBuilder()
+        .withFilingMode(filingMode)
+        .withCompanyName("Test Company")
+        .withCompanyNumber("LP123456")
+        .withStatus(TransactionStatus.closedPendingPayment)
+        .build();
+
+      appDevDependencies.transactionGateway.feedTransactions([transaction]);
+
+      // Resume link from the "Your filings" page carries no lang query param -
+      // the Welsh preference is recovered from the session instead (LP-1529)
+      const res = await request(app).get(RESUME_REGISTRATION_OR_TRANSITION_URL).set("x-session-lang", "cy");
+
+      expect(res.status).toEqual(302);
+      expect(res.headers.location).toEqual(appDevDependencies.paymentGateway.payment.links.journey);
+
       expect(appDevDependencies.paymentGateway.lastCreatePaymentRequest?.redirectUri).toEqual(
         `${expectedPaymentReturnUrl}?lang=cy`
       );

--- a/src/presentation/test/integration/language.middleware.test.ts
+++ b/src/presentation/test/integration/language.middleware.test.ts
@@ -1,0 +1,54 @@
+import { Request, Response, NextFunction } from "express";
+import { Session } from "@companieshouse/node-session-handler";
+
+import { languageMiddleware } from "../../../middlewares/language.middleware";
+import { setLocalesEnabled } from "../utils";
+
+describe("languageMiddleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    req = { query: {}, session: new Session() };
+    res = {};
+    next = jest.fn();
+    setLocalesEnabled(true);
+  });
+
+  it.each([["en"], ["cy"]])(
+    "stores the '%s' language on the session when the lang query param is present",
+    (lang) => {
+      (req.query as Record<string, string>).lang = lang;
+
+      languageMiddleware(req as Request, res as Response, next as NextFunction);
+
+      expect((req.session as Session).getLanguage()).toEqual(lang);
+      expect(next).toHaveBeenCalled();
+    }
+  );
+
+  it("normalises an unsupported language to 'en'", () => {
+    (req.query as Record<string, string>).lang = "fr";
+
+    languageMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect((req.session as Session).getLanguage()).toEqual("en");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("does not set a language when there is no lang query param", () => {
+    languageMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect((req.session as Session).getLanguage()).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("does not throw when there is no session on the request", () => {
+    req.session = undefined;
+    (req.query as Record<string, string>).lang = "cy";
+
+    expect(() => languageMiddleware(req as Request, res as Response, next as NextFunction)).not.toThrow();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/presentation/test/integration/localisation.middleware.test.ts
+++ b/src/presentation/test/integration/localisation.middleware.test.ts
@@ -1,0 +1,78 @@
+import { Request, Response, NextFunction } from "express";
+import { Session } from "@companieshouse/node-session-handler";
+
+import { localisationMiddleware } from "../../../middlewares/localisation.middleware";
+import { setLocalesEnabled } from "../utils";
+
+describe("localisationMiddleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.Mock;
+
+  const sessionWithLang = (lang: string): Session => {
+    const session = new Session();
+    session.setLanguage(lang);
+    return session;
+  };
+
+  beforeEach(() => {
+    req = { query: {}, session: undefined, originalUrl: "/limited-partnerships/some-page" };
+    res = { locals: {} };
+    next = jest.fn();
+    setLocalesEnabled(true);
+  });
+
+  it.each([["en"], ["cy"]])("uses a valid '%s' lang query param over the session language", (lang) => {
+    (req.query as Record<string, string>).lang = lang;
+    // session deliberately holds the opposite language to prove the query wins
+    req.session = sessionWithLang(lang === "en" ? "cy" : "en");
+
+    localisationMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect(res.locals?.lang).toEqual(lang);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("falls back to the session language when there is no lang query param", () => {
+    req.session = sessionWithLang("cy");
+
+    localisationMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect(res.locals?.lang).toEqual("cy");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("falls back to the session language when the lang query param is malformed", () => {
+    // reproduces the ?lang=cy?lang=cy double-append, which Express parses into
+    // an invalid value that would otherwise render the page in English (LP-1529)
+    (req.query as Record<string, string>).lang = "cy?lang=cy";
+    req.session = sessionWithLang("cy");
+
+    localisationMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect(res.locals?.lang).toEqual("cy");
+  });
+
+  it("lets an explicit lang=en query param override a Welsh session language", () => {
+    (req.query as Record<string, string>).lang = "en";
+    req.session = sessionWithLang("cy");
+
+    localisationMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect(res.locals?.lang).toEqual("en");
+  });
+
+  it("defaults to English when there is neither a query param nor a session language", () => {
+    localisationMiddleware(req as Request, res as Response, next as NextFunction);
+
+    expect(res.locals?.lang).toEqual("en");
+  });
+
+  it("does not throw when there is no session on the request", () => {
+    req.session = undefined;
+
+    expect(() => localisationMiddleware(req as Request, res as Response, next as NextFunction)).not.toThrow();
+    expect(res.locals?.lang).toEqual("en");
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-1529


### Change description

Resuming a Welsh payment rendered the confirmation/success screens in English because page language came only from the `lang` query param, which is missing on the resume link (and was sometimes mangled into `?lang=cy?lang=cy` by raw string concatenation). This makes the session the source of truth a new `languageMiddleware` persists the choice and `localisationMiddleware` now falls back to it and replaces the brittle URL concatenation with the existing query-param helpers.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.