### PR TITLE
small fix to show error message correctly

### DIFF
--- a/src/presentation/test/integration/registration/personWithSignificantControl/add-nature-of-control.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/add-nature-of-control.test.ts
@@ -345,7 +345,7 @@ describe("Add Nature of Control Page", () => {
           });
 
         expect(res.status).toBe(200);
-        expect(countOccurrences(res.text, toEscapedHtml(errorMessage))).toBe(1);
+        expect(countOccurrences(res.text, toEscapedHtml(errorMessage))).toBe(2);
       }
     );
 

--- a/src/views/pages/natureOfControl/nature-of-control-form.njk
+++ b/src/views/pages/natureOfControl/nature-of-control-form.njk
@@ -49,7 +49,7 @@
                     }
                 ],
                 errorMessage: {
-                    text: props.errors.share_of_assets.message
+                    text: props.errors.share_of_assets.text
                 } if props.errors.share_of_assets
             }) }}
 
@@ -81,7 +81,7 @@
                     }
                 ],
                 errorMessage: {
-                    text: props.errors.voting_rights.message
+                    text: props.errors.voting_rights.text
                 } if props.errors.voting_rights
             }) }}
 
@@ -125,7 +125,7 @@
                     }
                 ],
                 errorMessage: {
-                    text: props.errors.significant_influence_control.message
+                    text: props.errors.significant_influence_control.text
                 } if props.errors.significant_influence_control
             }) }}
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2059


### Change description
This pull request makes minor updates to error handling and test expectations related to the "Nature of Control" form. The main changes ensure that error messages are referenced consistently and that the test accurately reflects the rendered output.

Most important changes:

**Error message handling in the form:**

* Updated the `nature-of-control-form.njk` template to reference the `.text` property (instead of `.message`) for error messages on the `share_of_assets`, `voting_rights`, and `significant_influence_control` fields. This ensures the correct error text is displayed in the UI. [[1]](diffhunk://#diff-e70d853178e142b33ec38135f8ab4b874aa2f5017c81ec5deeb750290ba055eaL52-R52) [[2]](diffhunk://#diff-e70d853178e142b33ec38135f8ab4b874aa2f5017c81ec5deeb750290ba055eaL84-R84) [[3]](diffhunk://#diff-e70d853178e142b33ec38135f8ab4b874aa2f5017c81ec5deeb750290ba055eaL128-R128)

**Test expectation adjustment:**

* Updated the integration test for the "Add Nature of Control Page" to expect the error message to appear twice, reflecting the actual rendered output.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.