### PR TITLE
Added correct welsh error message for psc removal page

### DIFF
--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -206,6 +206,9 @@
                     "votingRightsMissing": "WELSH - Select whether the trustees of the trust hold any voting rights in the limited partnership",
                     "youMustSelectAtLeastOne": "WELSH - You must select at least one option that applies"
                 }
+            },
+            "removePscPage": {
+                "errorMessage": "WELSH - Select if you are sure you want to remove this PSC."
             }
         },
 

--- a/locales/cy/personWithSignificantControl.json
+++ b/locales/cy/personWithSignificantControl.json
@@ -208,8 +208,7 @@
             }
         },
         "removePscPage": {
-            "title": "WELSH - Are you sure you want to remove",
-            "errorMessage": "WELSH - Select yes if you need to remove a PSC"
+            "title": "WELSH - Are you sure you want to remove"
         },
         "reviewPage": {
             "title": "WELSH - Review the people with significant control (PSCs) for this partnership",

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -205,6 +205,9 @@
                     "votingRightsMissing": "Select whether the trustees of the trust hold any voting rights in the limited partnership",
                     "youMustSelectAtLeastOne": "You must select at least one option that applies"
                 }
+            },
+            "removePscPage": {
+                "errorMessage": "Select if you are sure you want to remove this PSC."
             }
         },
 

--- a/locales/en/personWithSignificantControl.json
+++ b/locales/en/personWithSignificantControl.json
@@ -209,8 +209,7 @@
             }
         },
         "removePscPage": {
-            "title": "Are you sure you want to remove",
-            "errorMessage": "Select if you are sure you want to remove this PSC."
+            "title": "Are you sure you want to remove"
         },
         "reviewPage": {
             "title": "Review the people with significant control (PSCs) for this partnership",

--- a/src/presentation/controller/registration/PersonWithSignificantControlController.ts
+++ b/src/presentation/controller/registration/PersonWithSignificantControlController.ts
@@ -637,7 +637,7 @@ class PersonWithSignificantControlRegistrationController extends AbstractControl
 
     const uiErrors = new UIErrors().setWebError(
       "remove",
-      response.locals.i18n.personWithSignificantControl.removePscPage.errorMessage
+      response.locals.i18n.errorMessages.personWithSignificantControl.removePscPage.errorMessage
     );
 
     return response.render(

--- a/src/presentation/test/integration/registration/personWithSignificantControl/remove-person-with-significant-control.test.ts
+++ b/src/presentation/test/integration/registration/personWithSignificantControl/remove-person-with-significant-control.test.ts
@@ -4,6 +4,8 @@ import enGeneralTranslationText from "../../../../../../locales/en/translations.
 import cyGeneralTranslationText from "../../../../../../locales/cy/translations.json";
 import enPersonWithSignificantControlTranslationText from "../../../../../../locales/en/personWithSignificantControl.json";
 import cyPersonWithSignificantControlTranslationText from "../../../../../../locales/cy/personWithSignificantControl.json";
+import enErrorTranslationsText from "../../../../../../locales/en/errors.json";
+import cyErrorTranslationsText from "../../../../../../locales/cy/errors.json";
 
 import app from "../../app";
 import { appDevDependencies } from "../../../../../config/dev-dependencies";
@@ -18,8 +20,8 @@ import {
 import RegistrationPageType from "../../../../controller/registration/PageType";
 
 describe("Remove Person With Significant Control Page", () => {
-  const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText };
-  const cyTranslationText = { ...cyGeneralTranslationText, ...cyPersonWithSignificantControlTranslationText };
+  const enTranslationText = { ...enGeneralTranslationText, ...enPersonWithSignificantControlTranslationText, ...enErrorTranslationsText };
+  const cyTranslationText = { ...cyGeneralTranslationText, ...cyPersonWithSignificantControlTranslationText, ...cyErrorTranslationsText };
   const URL = getUrl(REMOVE_PERSON_WITH_SIGNIFICANT_CONTROL_URL);
 
   const pscRle = new PersonWithSignificantControlBuilder()
@@ -128,7 +130,7 @@ describe("Remove Person With Significant Control Page", () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toContain(
-        enTranslationText.personWithSignificantControl.removePscPage.errorMessage
+        enTranslationText.errorMessages.personWithSignificantControl.removePscPage.errorMessage
       );
       expect(res.text).toContain(`${pscRle?.data?.legal_entity_name}`);
     });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2101


### Change description
added correct welsh translation for remove PSC page error message 
moved PSC message to errors.json 


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.