### PR TITLE
LP-2137 Add back links to GCI for post transition partnership landing pages

### DIFF
--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -3,7 +3,6 @@ import { CsrfError, InvalidAcspNumberError } from "@companieshouse/web-security-
 
 import { addLangToUrl, getLoggedInUserEmail, logger } from "../utils";
 import * as config from "../config/constants";
-import { PARTNERSHIP_TYPE_URL } from "../presentation/controller/registration/url";
 import { NOT_ELIGIBLE_URL } from "../presentation/controller/global/url";
 
 const pageNotFound = (req: Request, res: Response) => {
@@ -72,7 +71,7 @@ const globalErrorHandler = (err: Error, req: Request, res: Response, _next: Next
 };
 
 const getHeaderData = (req: Request) => {
-  const previous = req.get("Referrer") ?? PARTNERSHIP_TYPE_URL;
+  const previous = req.get("Referrer") ?? "/";
   const userEmail = getLoggedInUserEmail(req.session!);
 
   return {

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -4,6 +4,7 @@ import { CsrfError, InvalidAcspNumberError } from "@companieshouse/web-security-
 import { addLangToUrl, getLoggedInUserEmail, logger } from "../utils";
 import * as config from "../config/constants";
 import { NOT_ELIGIBLE_URL } from "../presentation/controller/global/url";
+import { PARTNERSHIP_TYPE_URL } from "../presentation/controller/registration/url";
 
 const pageNotFound = (req: Request, res: Response) => {
   const headerData = getHeaderData(req);
@@ -71,7 +72,7 @@ const globalErrorHandler = (err: Error, req: Request, res: Response, _next: Next
 };
 
 const getHeaderData = (req: Request) => {
-  const previous = req.get("Referrer") ?? "/";
+  const previous = req.get("Referrer") ?? PARTNERSHIP_TYPE_URL;
   const userEmail = getLoggedInUserEmail(req.session!);
 
   return {

--- a/src/presentation/controller/postTransition/LimitedPartnershipController.ts
+++ b/src/presentation/controller/postTransition/LimitedPartnershipController.ts
@@ -32,7 +32,6 @@ import TransactionService from "../../../application/service/TransactionService"
 import AddressService from "../../../application/service/AddressService";
 
 import { CONFIRMATION_POST_TRANSITION_URL, PAYMENT_RESPONSE_URL } from "../global/url";
-import { LANDING_PAGE_URL } from "./url";
 import PaymentService from "../../../application/service/PaymentService";
 
 class LimitedPartnershipController extends AbstractController {
@@ -56,6 +55,14 @@ class LimitedPartnershipController extends AbstractController {
         this.conditionalPreviousUrl(pageRouting, request);
 
         const limitedPartnership = await this.getLimitedPartnership(ids, tokens);
+
+        if (pageType === PostTransitionPageType.redesignateToPflp) {
+          // TODO - make this check a middleware and apply to all the redesignate routes and redirect to a new stop page?
+          this.blockIfPflpOrSpflp(
+            limitedPartnership?.data?.partnership_type as PartnershipType,
+            "Redesignate to PFLP is not allowed for PFLP or SPFLP partnership types"
+          );
+        }
 
         const submissionId = ids.submissionId;
 
@@ -170,17 +177,11 @@ class LimitedPartnershipController extends AbstractController {
 
         const limitedPartnership = await this.getLimitedPartnership(ids, tokens);
 
-        if (
-          limitedPartnership?.data?.partnership_type === PartnershipType.PFLP ||
-          limitedPartnership?.data?.partnership_type === PartnershipType.SPFLP
-        ) {
-          response.redirect(
-            super
-              .insertIdsInUrl(LANDING_PAGE_URL, ids, request.url)
-              .replace(JOURNEY_TYPE_PARAM, getJourneyTypes(request.url).journey)
-          );
-          return;
-        }
+        // TODO - make this check a middleware and apply to all routes on the term journey and redirect to a new stop page?
+        this.blockIfPflpOrSpflp(
+          limitedPartnership?.data?.partnership_type as PartnershipType,
+          "Term change is not allowed for PFLP or SPFLP partnership types"
+        );
 
         response.render(
           super.templateName(pageRouting.currentUrl),
@@ -632,6 +633,15 @@ class LimitedPartnershipController extends AbstractController {
         data: { ...limitedPartnership.data, ...data }
       }
     };
+  }
+
+  private blockIfPflpOrSpflp(partnershipType: PartnershipType, message: string) {
+    if (
+      partnershipType === PartnershipType.PFLP ||
+      partnershipType === PartnershipType.SPFLP
+    ) {
+      throw new Error(message);
+    }
   }
 }
 

--- a/src/presentation/controller/postTransition/routing/limitedPartnership.ts
+++ b/src/presentation/controller/postTransition/routing/limitedPartnership.ts
@@ -1,4 +1,4 @@
-import { COST_LP8D_REDESIGNATE_TO_PFLP } from "../../../../config";
+import { COST_LP8D_REDESIGNATE_TO_PFLP, YOUR_COMPANY_URL } from "../../../../config";
 import PostTransitionPageType from "../pageType";
 import * as url from "../url";
 
@@ -33,7 +33,7 @@ const postTransitionRoutingLandingPage = {
 };
 
 const postTransitionRoutingEnterRegisteredOfficeAddress = {
-  previousUrl: url.LANDING_PAGE_URL,
+  previousUrl: YOUR_COMPANY_URL,
   currentUrl: url.ENTER_REGISTERED_OFFICE_ADDRESS_URL,
   nextUrl: url.WHEN_DID_THE_REGISTERED_OFFICE_ADDRESS_CHANGE_URL,
   pageType: PostTransitionPageType.enterRegisteredOfficeAddress,
@@ -67,7 +67,7 @@ const postTransitionRoutingRegisteredOfficeAddressChangeCheckYourAnswers = {
 const PARTNERSHIP_NAME_KEY = "partnershipName";
 
 const postTransitionRoutingPartnershipName = {
-  previousUrl: url.LANDING_PAGE_URL,
+  previousUrl: YOUR_COMPANY_URL,
   currentUrl: url.PARTNERSHIP_NAME_URL,
   nextUrl: url.WHEN_DID_THE_PARTNERSHIP_NAME_CHANGE_URL,
   pageType: PostTransitionPageType.partnershipName,
@@ -97,7 +97,7 @@ const postTransitionRoutingPartnershipNameChangeCheckYourAnswers = {
 };
 
 const postTransitionRoutingTerm = {
-  previousUrl: url.LANDING_PAGE_URL,
+  previousUrl: YOUR_COMPANY_URL,
   currentUrl: url.TERM_URL,
   nextUrl: url.WHEN_DID_THE_TERM_CHANGE_URL,
   pageType: PostTransitionPageType.term,
@@ -129,7 +129,7 @@ const postTransitionRoutingTermChangeCheckYourAnswers = {
 };
 
 const postTransitionRoutingPrincipalPlaceOfBusinessAddress = {
-  previousUrl: url.LANDING_PAGE_URL,
+  previousUrl: YOUR_COMPANY_URL,
   currentUrl: url.ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_URL,
   nextUrl: url.WHEN_DID_THE_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_CHANGE_URL,
   pageType: PostTransitionPageType.enterPrincipalPlaceOfBusinessAddress,
@@ -161,7 +161,7 @@ const postTransitionRoutingPrincipalPlaceOfBusinessAddressChangeCheckYourAnswers
 };
 
 const postTransitionRoutingRedesignateToPFLP = {
-  previousUrl: url.LANDING_PAGE_URL,
+  previousUrl: YOUR_COMPANY_URL,
   currentUrl: url.REDESIGNATE_TO_PFLP_URL,
   nextUrl: "/",
   pageType: PostTransitionPageType.redesignateToPflp,

--- a/src/presentation/test/integration/postTransition/limitedPartnership/enter-principal-place-of-business-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/enter-principal-place-of-business-address.test.ts
@@ -31,6 +31,7 @@ import PostTransitionPageType from "../../../../../presentation/controller/postT
 import LimitedPartnershipBuilder from "../../../../../presentation/test/builder/LimitedPartnershipBuilder";
 import LimitedPartnerBuilder from "../../../builder/LimitedPartnerBuilder";
 import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feedback.middleware";
+import { YOUR_COMPANY_URL } from "../../../../../config";
 
 describe("Enter Principal Place Of Business Address Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
@@ -38,6 +39,7 @@ describe("Enter Principal Place Of Business Address Page", () => {
   const URL = getUrl(ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_URL);
   const URL_WITH_IDS = getUrl(ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_WITH_IDS_URL);
   const REDIRECT_URL = getUrl(WHEN_DID_THE_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_CHANGE_URL);
+  const BACK_LINK = getUrl(YOUR_COMPANY_URL);
 
   let companyProfile: { _id: string; data: Partial<CompanyProfile> };
 
@@ -88,6 +90,7 @@ describe("Enter Principal Place Of Business Address Page", () => {
         )
       ).toBe(2);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipPrincipalPlaceOfBusinessAddress);
+      expect(res.text).toContain(BACK_LINK);
     });
 
     it("should load the enter principal place of business address page with Welsh text", async () => {
@@ -114,6 +117,7 @@ describe("Enter Principal Place Of Business Address Page", () => {
         )
       ).toBe(2);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipPrincipalPlaceOfBusinessAddress);
+      expect(res.text).toContain(BACK_LINK);
     });
   });
 

--- a/src/presentation/test/integration/postTransition/limitedPartnership/enter-registered-office-address.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/enter-registered-office-address.test.ts
@@ -24,12 +24,14 @@ import LimitedPartnershipBuilder from "../../../../../presentation/test/builder/
 import CompanyProfileBuilder from "../../../../../presentation/test/builder/CompanyProfileBuilder";
 import PostTransitionPageType from "../../../../../presentation/controller/postTransition/pageType";
 import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feedback.middleware";
+import { YOUR_COMPANY_URL } from "../../../../../config";
 
 describe("Enter Registered Office Address Page", () => {
   const enTranslationText = { ...enGeneralTranslationText, ...enAddressTranslationText, ...enErrorsTranslationText };
   const cyTranslationText = { ...cyGeneralTranslationText, ...cyAddressTranslationText, ...cyErrorsTranslationText };
   const URL = getUrl(ENTER_REGISTERED_OFFICE_ADDRESS_URL);
   const URL_WITH_IDS = getUrl(ENTER_REGISTERED_OFFICE_ADDRESS_WITH_IDS_URL);
+  const BACK_LINK = getUrl(YOUR_COMPANY_URL);
 
   let companyProfile: { _id: string; data: Partial<CompanyProfile> };
 
@@ -67,6 +69,7 @@ describe("Enter Registered Office Address Page", () => {
         )
       ).toBe(2);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipRegisteredOfficeAddress);
+      expect(res.text).toContain(BACK_LINK);
     });
 
     it("should load the enter registered office address page with Welsh text", async () => {
@@ -91,6 +94,7 @@ describe("Enter Registered Office Address Page", () => {
         )
       ).toBe(2);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipRegisteredOfficeAddress);
+      expect(res.text).toContain(BACK_LINK);
     });
   });
 

--- a/src/presentation/test/integration/postTransition/limitedPartnership/partnership-name.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/partnership-name.test.ts
@@ -10,11 +10,13 @@ import { Jurisdiction, NameEndingType, PartnershipType } from "@companieshouse/a
 import LimitedPartnershipBuilder from "../../../../../presentation/test/builder/LimitedPartnershipBuilder";
 import PostTransitionPageType from "../../../../../presentation/controller/postTransition/pageType";
 import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feedback.middleware";
+import { YOUR_COMPANY_URL } from "../../../../../config/constants";
 
 describe("Name Page", () => {
   const URL = getUrl(PARTNERSHIP_NAME_URL);
   const REDIRECT_URL = getUrl(WHEN_DID_THE_PARTNERSHIP_NAME_CHANGE_URL);
-  let companyProfile;
+  const BACK_LINK = getUrl(YOUR_COMPANY_URL);
+  let companyProfile: any;
 
   beforeEach(() => {
     setLocalesEnabled(false);
@@ -52,8 +54,8 @@ describe("Name Page", () => {
       expect(res.text).toContain(`${expected.title} - ${cyTranslationText.serviceName.updateLimitedPartnershipName} - GOV.UK`);
       testTranslations(res.text, expected, exclude);
       expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
-      expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipName);
+      expect(res.text).toContain(BACK_LINK);
     });
 
     it.each([
@@ -82,6 +84,7 @@ describe("Name Page", () => {
       testTranslations(res.text, expected, exclude);
       expect(res.text).toContain(enTranslationText.buttons.saveAndContinue);
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipName);
+      expect(res.text).toContain(BACK_LINK);
     });
 
     it("should load the name page with data from api", async () => {

--- a/src/presentation/test/integration/postTransition/limitedPartnership/redesignate-to-pflp.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/redesignate-to-pflp.test.ts
@@ -9,8 +9,8 @@ import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from ".
 import { REDESIGNATE_TO_PFLP_URL } from "presentation/controller/postTransition/url";
 import CompanyProfileBuilder from "../../../builder/CompanyProfileBuilder";
 import PostTransitionPageType from "presentation/controller/postTransition/pageType";
-import { PartnershipType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
-import { TRANSACTION_DESCRIPTION_DESIGNATE_AS_PRIVATE_FUND_PARTNERSHIP } from "config";
+import { Jurisdiction, PartnershipType } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { TRANSACTION_DESCRIPTION_DESIGNATE_AS_PRIVATE_FUND_PARTNERSHIP, YOUR_COMPANY_URL } from "config";
 import LimitedPartnershipBuilder from "presentation/test/builder/LimitedPartnershipBuilder";
 import { ApiErrors } from "domain/entities/UIErrors";
 import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feedback.middleware";
@@ -18,7 +18,9 @@ import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feed
 describe("Redesignate to pflp page", () => {
   const URL = getUrl(REDESIGNATE_TO_PFLP_URL);
   const PAYMENT_LINK_JOURNEY = "https://api-test-payments.chs.local:4001";
-  let companyProfile;
+  const BACK_LINK = getUrl(YOUR_COMPANY_URL);
+
+  let companyProfile: any;
 
   beforeEach(() => {
     setLocalesEnabled(true);
@@ -42,6 +44,7 @@ describe("Redesignate to pflp page", () => {
       expect(countOccurrences(res.text, enTranslationText.serviceName.updateLimitedPartnershipRedesignateToPFLP)).toBe(2);
       expect(res.text).toContain(enTranslationText.redesignateToPflpPage.cost.replace("{{ cost }}", process.env.COST_LP8D_REDESIGNATE_TO_PFLP as string));
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipRedesignateToPFLP);
+      expect(res.text).toContain(BACK_LINK);
     });
 
     it("should load the page with Welsh text", async () => {
@@ -55,6 +58,7 @@ describe("Redesignate to pflp page", () => {
       expect(countOccurrences(res.text, cyTranslationText.serviceName.updateLimitedPartnershipRedesignateToPFLP)).toBe(2);
       expect(res.text).toContain(cyTranslationText.redesignateToPflpPage.cost.replace("{{ cost }}", process.env.COST_LP8D_REDESIGNATE_TO_PFLP as string));
       expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipRedesignateToPFLP);
+      expect(res.text).toContain(BACK_LINK);
     });
   });
 
@@ -102,6 +106,32 @@ describe("Redesignate to pflp page", () => {
 
       expect(res.status).toBe(500);
       expect(res.text).not.toContain(`Redirecting to ${PAYMENT_LINK_JOURNEY}`);
+    });
+  });
+
+  describe("should render the error page", () => {
+    it(`should render to error page if ${PartnershipType.PFLP}`, async () => {
+
+      companyProfile.data.subtype = "private-fund-limited-partnership";
+
+      appDevDependencies.companyGateway.feedCompanyProfile(companyProfile.data);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(500);
+      expect(res.text).toContain(enTranslationText.errorPage.title);
+    });
+
+    it(`should render the error page if ${PartnershipType.SPFLP}`, async () => {
+      companyProfile.data.jurisdiction = Jurisdiction.SCOTLAND;
+      companyProfile.data.subtype = "private-fund-limited-partnership";
+
+      appDevDependencies.companyGateway.feedCompanyProfile(companyProfile.data);
+
+      const res = await request(app).get(URL);
+
+      expect(res.status).toBe(500);
+      expect(res.text).toContain(enTranslationText.errorPage.title);
     });
   });
 });

--- a/src/presentation/test/integration/postTransition/limitedPartnership/term.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/term.test.ts
@@ -10,7 +10,6 @@ import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from ".
 import { ApiErrors } from "../../../../../domain/entities/UIErrors";
 
 import {
-  LANDING_PAGE_URL,
   TERM_URL,
   TERM_WITH_IDS_URL,
   WHEN_DID_THE_TERM_CHANGE_URL
@@ -25,7 +24,7 @@ describe("Email Page", () => {
   const URL = getUrl(TERM_URL);
   const REDIRECT_URL = getUrl(WHEN_DID_THE_TERM_CHANGE_URL);
 
-  let companyProfile;
+  let companyProfile: any;
 
   beforeEach(() => {
     setLocalesEnabled(true);
@@ -90,9 +89,8 @@ describe("Email Page", () => {
       });
     });
 
-    describe("should redirect to landing page", () => {
-      it(`should redirect to landing page if ${PartnershipType.PFLP}`, async () => {
-        const REDIRECT_URL = getUrl(LANDING_PAGE_URL);
+    describe("should render the error page", () => {
+      it(`should render to error page if ${PartnershipType.PFLP}`, async () => {
 
         companyProfile.data.subtype = "private-fund-limited-partnership";
 
@@ -100,13 +98,11 @@ describe("Email Page", () => {
 
         const res = await request(app).get(URL);
 
-        expect(res.status).toBe(302);
-        expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain(enTranslationText.errorPage.title);
       });
 
-      it(`should redirect to landing page if ${PartnershipType.SPFLP}`, async () => {
-        const REDIRECT_URL = getUrl(LANDING_PAGE_URL);
-
+      it(`should render the error page if ${PartnershipType.SPFLP}`, async () => {
         companyProfile.data.jurisdiction = Jurisdiction.SCOTLAND;
         companyProfile.data.subtype = "private-fund-limited-partnership";
 
@@ -114,8 +110,8 @@ describe("Email Page", () => {
 
         const res = await request(app).get(URL);
 
-        expect(res.status).toBe(302);
-        expect(res.text).toContain(`Redirecting to ${REDIRECT_URL}`);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain(enTranslationText.errorPage.title);
       });
     });
 

--- a/src/presentation/test/integration/postTransition/limitedPartnership/term.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartnership/term.test.ts
@@ -19,10 +19,12 @@ import PostTransitionPageType from "../../../../controller/postTransition/pageTy
 import CompanyProfileBuilder from "../../../builder/CompanyProfileBuilder";
 import { customerFeedbackUrlMap } from "../../../../../middlewares/customer-feedback.middleware";
 import TransactionBuilder from "../../../builder/TransactionBuilder";
+import { YOUR_COMPANY_URL } from "../../../../../config";
 
 describe("Email Page", () => {
   const URL = getUrl(TERM_URL);
   const REDIRECT_URL = getUrl(WHEN_DID_THE_TERM_CHANGE_URL);
+  const BACK_LINK = getUrl(YOUR_COMPANY_URL);
 
   let companyProfile: any;
 
@@ -48,6 +50,7 @@ describe("Email Page", () => {
         );
         expect(res.text).not.toContain("WELSH -");
         expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipTerm);
+        expect(res.text).toContain(BACK_LINK);
       });
 
       it("should load the page with Welsh text", async () => {
@@ -61,6 +64,7 @@ describe("Email Page", () => {
         testTranslations(res.text, cyTranslationText.termPage);
         expect(res.text).toContain(cyTranslationText.buttons.saveAndContinue);
         expect(res.text).toContain(customerFeedbackUrlMap.updateLimitedPartnershipTerm);
+        expect(res.text).toContain(BACK_LINK);
       });
 
       it("should load the page with ids", async () => {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2137


### Change description
Change the back links on the post transition start pages for limited partnerships updates to take the user to the 'company' page in CHS (aka GCI).

A couple of the pages should only be allowed for non PFLP/SPFLP, one of the pages would redirect to the mock/dummy landing page and the other would allow the incorrect type to continue. Raised it with Vernon and he is looking to get some stop pages created by UCD. In the meantime I have changed them to log an error and show the service unavailable page, as we don't want users to see the dummy landing page (in future should maybe feature flag the dummy page to toggle on for dev?) 

Also noticed the back link on the service unavailable page would take you to registration if no referer, so changed that to go to CH home page, as I was being taken from post transition to registration.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.