### PR TITLE
LP-2102 Fix redesignate pay now resume

### DIFF
--- a/src/presentation/controller/global/resumeUrlMapping.ts
+++ b/src/presentation/controller/global/resumeUrlMapping.ts
@@ -11,6 +11,7 @@ import {
   ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_WITH_IDS_URL,
   ENTER_REGISTERED_OFFICE_ADDRESS_WITH_IDS_URL,
   PARTNERSHIP_NAME_WITH_IDS_URL,
+  REDESIGNATE_TO_PFLP_URL,
   TERM_WITH_IDS_URL
 } from "../postTransition/url";
 
@@ -63,5 +64,9 @@ export const RESUME_PARTNERSHIP_URL_MAP: Record<string, { journey: string; resum
   [PartnershipKind.UPDATE_PARTNERSHIP_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS]: {
     journey: Journey.postTransition,
     resumeUrl: ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_WITH_IDS_URL
+  },
+  [PartnershipKind.UPDATE_PARTNERSHIP_REDESIGNATE_TO_PFLP]: {
+    journey: Journey.postTransition,
+    resumeUrl: REDESIGNATE_TO_PFLP_URL
   }
 };

--- a/src/presentation/test/integration/global/resume.test.ts
+++ b/src/presentation/test/integration/global/resume.test.ts
@@ -25,6 +25,7 @@ import {
   ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_WITH_IDS_URL,
   ENTER_REGISTERED_OFFICE_ADDRESS_WITH_IDS_URL,
   PARTNERSHIP_NAME_WITH_IDS_URL,
+  REDESIGNATE_TO_PFLP_URL,
   TERM_WITH_IDS_URL
 } from "presentation/controller/postTransition/url";
 
@@ -105,6 +106,11 @@ describe("Resume a journey", () => {
       resumeUrl: RESUME_POST_TRANSITION_PARTNERSHIP_URL,
       resourceKind: PartnershipKind.UPDATE_PARTNERSHIP_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS,
       expectedLocation: getUrl(ENTER_PRINCIPAL_PLACE_OF_BUSINESS_ADDRESS_WITH_IDS_URL)
+    },
+    {
+      resumeUrl: RESUME_POST_TRANSITION_PARTNERSHIP_URL,
+      resourceKind: PartnershipKind.UPDATE_PARTNERSHIP_REDESIGNATE_TO_PFLP,
+      expectedLocation: getUrl(REDESIGNATE_TO_PFLP_URL)
     }
   ])(
     "should resume a no payment post-transition $resourceKind journey",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2102


### Change description
When resuming a redesignate to pflp journey that was at the payment stage then the user would get a failure.
The url was missing from the resume lookup map.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.