### PR TITLE
LP-2191 fix locales CiDev loading

### DIFF
--- a/src/utils/countries.ts
+++ b/src/utils/countries.ts
@@ -1,9 +1,11 @@
-import enCountriesText from "../../locales/en/countries.json";
+import { loadLocaleJson } from "./locale-loader";
+
+const enCountriesText = loadLocaleJson<{ countries: Record<string, string> }>("countries.json");
 
 export const setCountriesDropdown = (i18n: Record<string, any>, countryField: string) => {
   const countries: { value: string; text: string; selected: boolean }[] = [];
   const ukCountries: { value: string; text: string; selected: boolean }[] = [];
-  const enCountries = enCountriesText.countries as Record<string, string>;
+  const enCountries = enCountriesText.countries;
 
   const ukCountriesKeys = ["england", "scotland", "wales", "northernIreland"];
 

--- a/src/utils/locale-loader.ts
+++ b/src/utils/locale-loader.ts
@@ -1,10 +1,12 @@
 import { readFileSync } from "fs";
 import path from "path";
 
+// service fails to start in CI-Dev if using relative path to locales folder,
+// so this utility uses an absolute path to the locales folder to load the json files
 const LOCALES_PATH = path.resolve(process.cwd(), "locales");
 
-export const loadLocaleJson = <T>(fileName: string): T => {
-  const filePath = path.join(LOCALES_PATH, "en", fileName);
+export const loadLocaleJson = <T>(fileName: string, locale: string = "en"): T => {
+  const filePath = path.join(LOCALES_PATH, locale, fileName);
   const fileContents = readFileSync(filePath, "utf-8");
   return JSON.parse(fileContents) as T;
 };

--- a/src/utils/locale-loader.ts
+++ b/src/utils/locale-loader.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+const LOCALES_PATH = path.resolve(process.cwd(), "locales");
+
+export const loadLocaleJson = <T>(fileName: string): T => {
+  const filePath = path.join(LOCALES_PATH, "en", fileName);
+  const fileContents = readFileSync(filePath, "utf-8");
+  return JSON.parse(fileContents) as T;
+};

--- a/src/utils/nationalities.ts
+++ b/src/utils/nationalities.ts
@@ -1,9 +1,11 @@
-import enNationalitiesText from "../../locales/en/nationalities.json";
+import { loadLocaleJson } from "./locale-loader";
+
+const enNationalitiesText = loadLocaleJson<{ nationalities: Record<string, string> }>("nationalities.json");
 
 export const setNationalitiesDropdown = (i18n: Record<string, any>, nationalityField: string | undefined, selectPrompt: string) => {
   const nationalities: { value: string; text: string; selected: boolean }[] = [];
   const ukNationalities: { value: string; text: string; selected: boolean }[] = [];
-  const enNationalities = enNationalitiesText.nationalities as Record<string, string>;
+  const enNationalities = enNationalitiesText.nationalities;
 
   const ukNationalitiesKeys = ["british", "english", "northernIrish", "scottish", "welsh"];
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2191


### Change description
The service fails to start in Cidev as the locales files are copied to a different folder and then the static import is incorrect.
`"created":"2026-07-29T09:06:51.657+00:00","event":"error","namespace":"web-security-node","data":{"message":"uncaughtException: Cannot find module '../../locales/en/countries.json'\nRequire stack:\n- /opt/utils/countries.js\n- /opt/config/app-config.js\n- /opt/config/index.js\n- /opt/bin/www.js\nError: Cannot find module '../../locales/en/countries.json'\nRequire stack:\n- /opt/utils/countries.js\n- /opt/config/app-config.js\n- /opt/config/index.js\n- /opt/bin/www.js\n at Module._resolveFilename (node:internal/modules/cjs/loader:1456:15)\n at defaultResolveImpl (node:internal/modules/cjs/loader:1066:19)\n at `

Gone back to a similar approach to what was previously used but replaced the use of 'require' as TS doesn't like it (warnings).

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.