### PR TITLE
LP-2200 Add fieldsets to NOC pages

### DIFF
--- a/src/views/pages/natureOfControl/nature-of-control-form.njk
+++ b/src/views/pages/natureOfControl/nature-of-control-form.njk
@@ -21,11 +21,18 @@
             <input type="hidden" name="type" value={{ props.data.natureOfControlType }}>
             {% include "includes/csrf_token.njk" %}
 
-            <h2 class="govuk-heading-m">{{ translationText.shareOfAssets }}</h2>
-            <p class="govuk-body">{{ shareOfAssetsHint }}</p>
-
             {{ govukRadios({
                 name: "share_of_assets",
+                fieldset: {
+                    legend: {
+                        text: translationText.shareOfAssets,
+                        isPageHeading: false,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                hint: {
+                    text: shareOfAssetsHint
+                },
                 items: [
                     {
                         value: "share_of_assets_25_to_50",
@@ -53,11 +60,18 @@
                 } if props.errors.share_of_assets
             }) }}
 
-            <h2 class="govuk-heading-m">{{ translationText.votingRights }}</h2>
-            <p class="govuk-body">{{ votingRightsHint }}</p>
-
             {{ govukRadios({
                 name: "voting_rights",
+                fieldset: {
+                    legend: {
+                        text: translationText.votingRights,
+                        isPageHeading: false,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                hint: {
+                    text: votingRightsHint
+                },
                 items: [
                     {
                         value: "voting_rights_25_to_50",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2200


### Change description
Add fieldsets to the NOC radio buttons to fix accessibility issues


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.