### PR TITLE
LP-2194 Create common partner values check for tests

### DIFF
--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { checkPartnerValuesInText, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
@@ -9,8 +9,7 @@ import {
   CONFIRM_GENERAL_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL,
   CONFIRM_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_URL
 } from "../../../../../controller/addressLookUp/url/postTransition";
-import { GeneralPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
-import { formatDate } from "../../../../../../utils/date-format";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
 import { CONFIRMATION_POST_TRANSITION_URL } from "../../../../../controller/global/url";
 import TransactionBuilder from "../../../../builder/TransactionBuilder";
@@ -19,6 +18,12 @@ import { enTranslationText, cyTranslationText } from "../../../../../../test/uti
 describe("Check Your Answers Page", () => {
   const URL = getUrl(GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL);
   const REDIRECT_URL = getUrl(CONFIRMATION_POST_TRANSITION_URL);
+  const legalEntityPartnerValueChecks = {
+    dateKeyIncludes: ["date_effective_from"],
+    addressKeyIncludes: ["principal_office_address"],
+    assertOtherStringValues: true,
+    skipOtherIfKeyIncludes: ["address"]
+  };
 
   let companyProfile;
   let generalPartnerLegalEntity: TransactionGeneralPartner;
@@ -115,7 +120,7 @@ describe("Check Your Answers Page", () => {
         "ceaseDate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, enTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, enTranslationText, legalEntityPartnerValueChecks);
     });
 
     it("should load the check your answers page with partners - CY", async () => {
@@ -136,7 +141,7 @@ describe("Check Your Answers Page", () => {
         "ceaseDate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, cyTranslationText, legalEntityPartnerValueChecks);
     });
   });
   describe("POST Check Your Answers Page", () => {
@@ -159,20 +164,3 @@ describe("Check Your Answers Page", () => {
   });
 });
 
-const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "principal_office_address") {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (!key.includes("address")) {
-        expect(res.text).toContain(partner.data[key]);
-      }
-    }
-  }
-};

--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
@@ -5,9 +5,8 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { GeneralPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkPartnerValuesInText, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_URL, CONFIRM_GENERAL_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
 import { CONFIRMATION_POST_TRANSITION_URL } from "../../../../../controller/global/url";
@@ -86,7 +85,11 @@ describe("General Partner Check Your Answers Page", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, generalPartnerPerson, enTranslationText);
+    checkPartnerValuesInText(res, generalPartnerPerson, enTranslationText, {
+      capitalizeKeys: ["nationality1"],
+      dateKeyIncludes: ["date_of_birth", "date_effective_from"],
+      addressKeyIncludes: ["usual_residential_address"]
+    });
   });
 
   describe("POST Check Your Answers Page", () => {
@@ -108,26 +111,3 @@ describe("General Partner Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
-
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("usual_residential_address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      }
-    }
-  }
-};
-

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
@@ -4,9 +4,8 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import LimitedPartnerBuilder from "../../../../builder/LimitedPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkPartnerValuesInText, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import {
   CONFIRM_LIMITED_PARTNER_USUAL_RESIDENTIAL_ADDRESS_URL,
   CONFIRM_LIMITED_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL
@@ -86,7 +85,12 @@ describe("Limited Partner Check Your Answers Page", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
+    checkPartnerValuesInText(res, limitedPartnerLegalEntity, enTranslationText, {
+      dateKeyIncludes: ["date_effective_from"],
+      addressKeyIncludes: ["principal_office_address"],
+      assertOtherStringValues: true,
+      skipOtherIfKeyIncludes: ["address"]
+    });
   });
 
   it.each([
@@ -137,20 +141,3 @@ describe("Limited Partner Check Your Answers Page", () => {
   });
 });
 
-const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "principal_office_address") {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (!key.includes("address")) {
-        expect(res.text).toContain(partner.data[key]);
-      }
-    }
-  }
-};

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
@@ -4,9 +4,8 @@ import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkPartnerValuesInText, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_LIMITED_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL, CONFIRM_LIMITED_PARTNER_USUAL_RESIDENTIAL_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
 import LimitedPartnerBuilder from "../../../../../../presentation/test/builder/LimitedPartnerBuilder";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
@@ -17,6 +16,11 @@ import { enTranslationText, cyTranslationText } from "../../../../../../test/uti
 describe("Limited Partner Check Your Answers Page for Person", () => {
   const URL = getUrl(LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL);
   const REDIRECT_URL = getUrl(CONFIRMATION_POST_TRANSITION_URL);
+  const personPartnerValueChecks = {
+    capitalizeKeys: ["nationality1"],
+    dateKeyIncludes: ["date_of_birth", "date_effective_from"],
+    addressKeyIncludes: ["usual_residential_address"]
+  };
 
   let limitedPartnerPerson;
 
@@ -98,7 +102,7 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+    checkPartnerValuesInText(res, limitedPartnerPerson, enTranslationText, personPartnerValueChecks);
   });
 
   it("should load the check your answers page with partners with dates- EN", async () => {
@@ -115,7 +119,7 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+    checkPartnerValuesInText(res, limitedPartnerPerson, enTranslationText, personPartnerValueChecks);
   });
 
   it.each([
@@ -169,26 +173,3 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
-
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("usual_residential_address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      }
-    }
-  }
-};
-

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -2,15 +2,13 @@ import request from "supertest";
 import app from "../app";
 
 import {
-  GeneralPartner,
-  LimitedPartner,
   Jurisdiction,
   PartnershipType
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CHECK_YOUR_ANSWERS_URL, REVIEW_LIMITED_PARTNERS_URL, REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL, WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL } from "../../../controller/registration/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { checkPartnerValuesInText, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
@@ -35,6 +33,13 @@ import { enTranslationText, cyTranslationText } from "../../../../test/utils/loc
 describe("Check Your Answers Page", () => {
   const URL = getUrl(CHECK_YOUR_ANSWERS_URL);
   const PAYMENT_LINK_JOURNEY = "https://api-test-payments.chs.local:4001";
+  const partnerValueChecks = {
+    capitalizeKeys: ["nationality1"],
+    dateKeyIncludes: ["date_of_birth"],
+    addressKeyIncludes: ["address"],
+    contributionSubtypeKeyIncludes: ["contribution_sub_types"],
+    assertOtherStringValues: true
+  };
 
   let limitedPartnership: TransactionLimitedPartnership;
   let generalPartnerPerson: TransactionGeneralPartner;
@@ -292,13 +297,13 @@ describe("Check Your Answers Page", () => {
       "psc"
     ]);
 
-    checkIfValuesInText(res, generalPartnerPerson, translationText);
+    checkPartnerValuesInText(res, generalPartnerPerson, translationText, partnerValueChecks);
 
-    checkIfValuesInText(res, generalPartnerLegalEntity, translationText);
+    checkPartnerValuesInText(res, generalPartnerLegalEntity, translationText, partnerValueChecks);
 
-    checkIfValuesInText(res, limitedPartnerPerson, translationText);
+    checkPartnerValuesInText(res, limitedPartnerPerson, translationText, partnerValueChecks);
 
-    checkIfValuesInText(res, limitedPartnerLegalEntity, translationText);
+    checkPartnerValuesInText(res, limitedPartnerLegalEntity, translationText, partnerValueChecks);
 
     expect(res.text).toContain(translationText.nationalities.british);
     expect(res.text).toContain(countriesText.countries.unitedStates);
@@ -686,43 +691,3 @@ describe("Check Your Answers Page", () => {
   });
 });
 
-const checkIfValuesInText = (
-  res: request.Response,
-  partner: GeneralPartner | LimitedPartner,
-  translationText: Record<string, any>
-) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value === "string" || typeof value === "object") {
-      if (key === "nationality1") {
-        const capitalized = value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
-
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && value) {
-        expect(res.text).toContain(formatDate(value, translationText));
-      } else if (key.includes("address")) {
-        const capitalized = value.address_line_1
-          .split(" ")
-          .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("contribution_sub_types")) {
-        const capitalContributionSubTypesMap: Record<string, string> = {
-          MONEY: translationText.capitalContribution.money,
-          LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
-          SHARES: translationText.capitalContribution.shares,
-          SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
-          ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
-        };
-
-        const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
-        expect(res.text).toContain(str.replaceAll("_", " "));
-      } else {
-        expect(res.text).toContain(value);
-      }
-    }
-  }
-};

--- a/src/presentation/test/integration/transition/check-your-answers.test.ts
+++ b/src/presentation/test/integration/transition/check-your-answers.test.ts
@@ -2,17 +2,14 @@ import request from "supertest";
 import app from "../app";
 
 import {
-  GeneralPartner,
-  LimitedPartner,
   PartnershipType
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CHECK_YOUR_ANSWERS_URL } from "../../../controller/transition/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { checkPartnerValuesInText, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
-import { formatDate } from "../../../../utils/date-format";
 import { TransactionKind } from "../../../../domain/entities/TransactionTypes";
 import TransactionBuilder from "../../builder/TransactionBuilder";
 import TransitionPageType from "../../../controller/transition/PageType";
@@ -24,6 +21,12 @@ import { enTranslationText, cyTranslationText } from "../../../../test/utils/loc
 describe("Check Your Answers Page", () => {
   const URL = getUrl(CHECK_YOUR_ANSWERS_URL);
   const REDIRECT_URL = getUrl(CONFIRMATION_URL).replace(JOURNEY_TYPE_PARAM, Journey.transition);
+  const partnerValueChecks = {
+    capitalizeKeys: ["nationality1"],
+    dateKeyIncludes: ["date_of_birth"],
+    addressKeyIncludes: ["address"],
+    assertOtherStringValues: true
+  };
 
   let limitedPartnership;
   let generalPartnerPerson;
@@ -165,13 +168,13 @@ describe("Check Your Answers Page", () => {
         "warningMessageUpdate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerPerson, enTranslationText);
+      checkPartnerValuesInText(res, generalPartnerPerson, enTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, enTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, enTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerPerson, enTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerLegalEntity, enTranslationText, partnerValueChecks);
 
       expect(res.text).toContain(enTranslationText.nationalities.british);
       expect(res.text).toContain(enTranslationText.countries.unitedStates);
@@ -193,13 +196,13 @@ describe("Check Your Answers Page", () => {
         "warningMessageUpdate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerPerson, cyTranslationText);
+      checkPartnerValuesInText(res, generalPartnerPerson, cyTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, cyTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, limitedPartnerPerson, cyTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerPerson, cyTranslationText, partnerValueChecks);
 
-      checkIfValuesInText(res, limitedPartnerLegalEntity, cyTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerLegalEntity, cyTranslationText, partnerValueChecks);
 
       expect(res.text).toContain(cyTranslationText.nationalities.british);
       expect(res.text).toContain(cyTranslationText.countries.unitedStates);
@@ -218,27 +221,3 @@ describe("Check Your Answers Page", () => {
   });
 });
 
-const checkIfValuesInText = (
-  res: request.Response,
-  partner: GeneralPartner | LimitedPartner,
-  translationText: Record<string, any>
-) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else {
-        expect(res.text).toContain(partner.data[key]);
-      }
-    }
-  }
-};

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -7,6 +7,16 @@ import GeneralPartnerBuilder from "./builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "./builder/LimitedPartnerBuilder";
 import request from "supertest";
 import PersonWithSignificantControlBuilder from "./builder/PersonWithSignificantControlBuilder";
+import { formatDate } from "../../utils/date-format";
+
+type CheckPartnerValuesInTextOptions = {
+  capitalizeKeys?: string[];
+  dateKeyIncludes?: string[];
+  addressKeyIncludes?: string[];
+  contributionSubtypeKeyIncludes?: string[];
+  assertOtherStringValues?: boolean;
+  skipOtherIfKeyIncludes?: string[];
+};
 
 export const setLocalesEnabled = (bool: boolean) => {
   jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
@@ -129,4 +139,73 @@ export const createPersonWithSignificantControl = (url: string, urlToCompare: st
     personWithSignificantControl.build()
   ]);
   return personWithSignificantControl;
+};
+
+const includesAnyPattern = (key: string, patterns: string[] = []): boolean => {
+  return patterns.some((pattern) => key.includes(pattern));
+};
+
+const titleCaseWords = (value: string): string => {
+  return value
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+};
+
+export const checkPartnerValuesInText = (
+  res: request.Response,
+  partner: LimitedPartner | GeneralPartner,
+  translationText: Record<string, any>,
+  options: CheckPartnerValuesInTextOptions = {}
+) => {
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (options.capitalizeKeys?.includes(key) && typeof value === "string") {
+      expect(res.text).toContain(value.charAt(0).toUpperCase() + value.slice(1).toLowerCase());
+      continue;
+    }
+
+    if (includesAnyPattern(key, options.dateKeyIncludes) && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+      continue;
+    }
+
+    if (includesAnyPattern(key, options.addressKeyIncludes) && typeof value === "object" && value.address_line_1) {
+      expect(res.text).toContain(titleCaseWords(value.address_line_1));
+      continue;
+    }
+
+    if (includesAnyPattern(key, options.contributionSubtypeKeyIncludes) && Array.isArray(value)) {
+      const capitalContributionSubTypesMap: Record<string, string> = {
+        MONEY: translationText.capitalContribution.money,
+        LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
+        SHARES: translationText.capitalContribution.shares,
+        SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
+        ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
+      };
+
+      const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
+      expect(res.text).toContain(str.split("_").join(" "));
+      continue;
+    }
+
+    if (
+      options.assertOtherStringValues &&
+      typeof value === "string" &&
+      !includesAnyPattern(key, options.skipOtherIfKeyIncludes)
+    ) {
+      expect(res.text).toContain(value);
+    }
+  }
 };

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -152,6 +152,93 @@ const titleCaseWords = (value: string): string => {
     .join(" ");
 };
 
+const resolvePartnerCapitalizedValue = (
+  key: string,
+  value: unknown,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  if (typeof value !== "string" || !options.capitalizeKeys?.includes(key)) {
+    return undefined;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+};
+
+const resolvePartnerDateValue = (
+  key: string,
+  value: unknown,
+  translationText: Record<string, any>,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  if (!value || !includesAnyPattern(key, options.dateKeyIncludes)) {
+    return undefined;
+  }
+  return formatDate(value as string, translationText);
+};
+
+const resolvePartnerAddressValue = (
+  key: string,
+  value: unknown,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  const addressLine1 = (value as { address_line_1?: string })?.address_line_1;
+  if (!addressLine1 || !includesAnyPattern(key, options.addressKeyIncludes)) {
+    return undefined;
+  }
+  return titleCaseWords(addressLine1);
+};
+
+const resolvePartnerContributionSubtypeValue = (
+  key: string,
+  value: unknown,
+  translationText: Record<string, any>,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  if (!Array.isArray(value) || !includesAnyPattern(key, options.contributionSubtypeKeyIncludes)) {
+    return undefined;
+  }
+
+  const capitalContributionSubTypesMap: Record<string, string> = {
+    MONEY: translationText.capitalContribution.money,
+    LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
+    SHARES: translationText.capitalContribution.shares,
+    SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
+    ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
+  };
+
+  return value
+    .map((word: string) => capitalContributionSubTypesMap[word])
+    .join(" / ")
+    .split("_")
+    .join(" ");
+};
+
+const resolvePartnerOtherStringValue = (
+  key: string,
+  value: unknown,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  if (typeof value !== "string" || !options.assertOtherStringValues) {
+    return undefined;
+  }
+  return includesAnyPattern(key, options.skipOtherIfKeyIncludes) ? undefined : value;
+};
+
+// tries each rule in turn and uses the first one that applies to this key/value
+const resolvePartnerExpectedText = (
+  key: string,
+  value: unknown,
+  translationText: Record<string, any>,
+  options: CheckPartnerValuesInTextOptions
+): string | undefined => {
+  return (
+    resolvePartnerCapitalizedValue(key, value, options) ??
+    resolvePartnerDateValue(key, value, translationText, options) ??
+    resolvePartnerAddressValue(key, value, options) ??
+    resolvePartnerContributionSubtypeValue(key, value, translationText, options) ??
+    resolvePartnerOtherStringValue(key, value, options)
+  );
+};
+
 export const checkPartnerValuesInText = (
   res: request.Response,
   partner: LimitedPartner | GeneralPartner,
@@ -171,41 +258,10 @@ export const checkPartnerValuesInText = (
       continue;
     }
 
-    if (options.capitalizeKeys?.includes(key) && typeof value === "string") {
-      expect(res.text).toContain(value.charAt(0).toUpperCase() + value.slice(1).toLowerCase());
-      continue;
-    }
+    const expected = resolvePartnerExpectedText(key, value, translationText, options);
 
-    if (includesAnyPattern(key, options.dateKeyIncludes) && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-      continue;
-    }
-
-    if (includesAnyPattern(key, options.addressKeyIncludes) && typeof value === "object" && value.address_line_1) {
-      expect(res.text).toContain(titleCaseWords(value.address_line_1));
-      continue;
-    }
-
-    if (includesAnyPattern(key, options.contributionSubtypeKeyIncludes) && Array.isArray(value)) {
-      const capitalContributionSubTypesMap: Record<string, string> = {
-        MONEY: translationText.capitalContribution.money,
-        LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
-        SHARES: translationText.capitalContribution.shares,
-        SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
-        ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
-      };
-
-      const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
-      expect(res.text).toContain(str.split("_").join(" "));
-      continue;
-    }
-
-    if (
-      options.assertOtherStringValues &&
-      typeof value === "string" &&
-      !includesAnyPattern(key, options.skipOtherIfKeyIncludes)
-    ) {
-      expect(res.text).toContain(value);
+    if (expected !== undefined) {
+      expect(res.text).toContain(expected);
     }
   }
 };


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2194


### Change description
Create a common partner values checker that tests can use


This pull request refactors several integration tests by removing the duplicated `checkIfValuesInText` helper function and replacing it with a new, more flexible `checkPartnerValuesInText` utility. The new helper is imported and used across all relevant test files, and test cases are updated to pass configuration objects for partner value checks. This change improves code reuse, maintainability, and readability in the test suite.

**Test Helper Refactoring and Standardization:**

* Replaced the old `checkIfValuesInText` helper with the new `checkPartnerValuesInText` utility in all relevant test files, and updated imports accordingly. The new utility is now consistently used to assert partner data on "Check Your Answers" pages. [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL4-R12) [[2]](diffhunk://#diff-1db674ddd838c97f36ff9bcea606a8076f22079355a7f9b7120c0be7e9c20fdcL8-R9) [[3]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL7-R8) [[4]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L7-R8) [[5]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L5-R11)
* Removed all local definitions of `checkIfValuesInText` from the test files, eliminating code duplication. [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL162-L178) [[2]](diffhunk://#diff-1db674ddd838c97f36ff9bcea606a8076f22079355a7f9b7120c0be7e9c20fdcL111-L133) [[3]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL140-L156) [[4]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L172-L194) [[5]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L689-L728)

**Test Case Updates:**

* Updated test cases to use `checkPartnerValuesInText`, passing in configuration objects to customize value checks per test scenario (e.g., which keys to capitalize, date keys, address keys, etc.). [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eR21-R26) [[2]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL118-R123) [[3]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL139-R144) [[4]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL89-R93) [[5]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283R19-R23) [[6]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L101-R105) [[7]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L118-R122) [[8]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88R36-R42) [[9]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L295-R306)

These changes centralize and standardize partner value assertions, making the tests easier to maintain and extend.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.