### PR TITLE
Lp 2194 simplify check if values in text

### DIFF
--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
-import { capitalize, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { checkLegalEntityValuesInText, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
@@ -9,8 +9,7 @@ import {
   CONFIRM_GENERAL_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL,
   CONFIRM_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_URL
 } from "../../../../../controller/addressLookUp/url/postTransition";
-import { GeneralPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
-import { formatDate } from "../../../../../../utils/date-format";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships/types";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
 import { CONFIRMATION_POST_TRANSITION_URL } from "../../../../../controller/global/url";
 import TransactionBuilder from "../../../../builder/TransactionBuilder";
@@ -115,7 +114,7 @@ describe("Check Your Answers Page", () => {
         "ceaseDate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, enTranslationText);
+      checkLegalEntityValuesInText(res, generalPartnerLegalEntity, enTranslationText);
     });
 
     it("should load the check your answers page with partners - CY", async () => {
@@ -136,7 +135,7 @@ describe("Check Your Answers Page", () => {
         "ceaseDate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
+      checkLegalEntityValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
     });
   });
   describe("POST Check Your Answers Page", () => {
@@ -158,23 +157,3 @@ describe("Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "principal_office_address") {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (!key.includes("address")) {
-      expect(res.text).toContain(value);
-    }
-  }
-};

--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-legal-entity.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { capitalize, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
@@ -160,19 +160,21 @@ describe("Check Your Answers Page", () => {
 });
 
 const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "principal_office_address") {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (!key.includes("address")) {
-        expect(res.text).toContain(partner.data[key]);
-      }
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "principal_office_address") {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (!key.includes("address")) {
+      expect(res.text).toContain(value);
     }
   }
 };

--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
@@ -5,9 +5,8 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { capitalize, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { GeneralPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkPersonValuesInText, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_URL, CONFIRM_GENERAL_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
 import { CONFIRMATION_POST_TRANSITION_URL } from "../../../../../controller/global/url";
@@ -86,7 +85,7 @@ describe("General Partner Check Your Answers Page", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, generalPartnerPerson, enTranslationText);
+    checkPersonValuesInText(res, generalPartnerPerson, enTranslationText);
   });
 
   describe("POST Check Your Answers Page", () => {
@@ -108,26 +107,4 @@ describe("General Partner Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "nationality1") {
-      expect(res.text).toContain(capitalize(value));
-    } else if (key.includes("date_of_birth") && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (key.includes("usual_residential_address")) {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    }
-  }
-};
 

--- a/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/generalPartner/checkYourAnswer/general-partner-check-your-answers-person.test.ts
@@ -5,7 +5,7 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import GeneralPartnerBuilder from "../../../../builder/GeneralPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { GENERAL_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { capitalize, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
 import { formatDate } from "../../../../../../utils/date-format";
 import { GeneralPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_GENERAL_PARTNER_CORRESPONDENCE_ADDRESS_URL, CONFIRM_GENERAL_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
@@ -110,23 +110,23 @@ describe("General Partner Check Your Answers Page", () => {
 });
 
 const checkIfValuesInText = (res: request.Response, partner: GeneralPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
+  const partnerData = partner.data as Record<string, any>;
 
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("usual_residential_address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      }
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "nationality1") {
+      expect(res.text).toContain(capitalize(value));
+    } else if (key.includes("date_of_birth") && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (key.includes("usual_residential_address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
     }
   }
 };

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
@@ -4,7 +4,7 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import LimitedPartnerBuilder from "../../../../builder/LimitedPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { capitalize, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
 import { formatDate } from "../../../../../../utils/date-format";
 import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import {
@@ -138,19 +138,21 @@ describe("Limited Partner Check Your Answers Page", () => {
 });
 
 const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "principal_office_address") {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (!key.includes("address")) {
-        expect(res.text).toContain(partner.data[key]);
-      }
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "principal_office_address") {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (!key.includes("address")) {
+      expect(res.text).toContain(value);
     }
   }
 };

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-legal-entity.test.ts
@@ -4,9 +4,8 @@ import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import LimitedPartnerBuilder from "../../../../builder/LimitedPartnerBuilder";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { capitalize, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkLegalEntityValuesInText, countOccurrences, getUrl, setLocalesEnabled } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import {
   CONFIRM_LIMITED_PARTNER_USUAL_RESIDENTIAL_ADDRESS_URL,
   CONFIRM_LIMITED_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL
@@ -86,7 +85,7 @@ describe("Limited Partner Check Your Answers Page", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
+    checkLegalEntityValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
   });
 
   it.each([
@@ -136,23 +135,3 @@ describe("Limited Partner Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "principal_office_address") {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (!key.includes("address")) {
-      expect(res.text).toContain(value);
-    }
-  }
-};

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
@@ -4,9 +4,8 @@ import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { capitalize, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
-import { formatDate } from "../../../../../../utils/date-format";
-import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
+import { checkPersonValuesInText, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_LIMITED_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL, CONFIRM_LIMITED_PARTNER_USUAL_RESIDENTIAL_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
 import LimitedPartnerBuilder from "../../../../../../presentation/test/builder/LimitedPartnerBuilder";
 import PostTransitionPageType from "../../../../../controller/postTransition/pageType";
@@ -98,7 +97,7 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+    checkPersonValuesInText(res, limitedPartnerPerson, enTranslationText);
   });
 
   it("should load the check your answers page with partners with dates- EN", async () => {
@@ -115,7 +114,7 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     const res = await request(app).get(URL);
 
     expect(res.status).toBe(200);
-    checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+    checkPersonValuesInText(res, limitedPartnerPerson, enTranslationText);
   });
 
   it.each([
@@ -169,26 +168,4 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
     });
   });
 });
-
-const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "nationality1") {
-      expect(res.text).toContain(capitalize(value));
-    } else if (key.includes("date_of_birth") && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (key.includes("usual_residential_address")) {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    }
-  }
-};
 

--- a/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
+++ b/src/presentation/test/integration/postTransition/limitedPartner/checkYourAnswer/limited-partner-check-your-answers-person.test.ts
@@ -4,7 +4,7 @@ import app from "../../../app";
 import { appDevDependencies } from "../../../../../../config/dev-dependencies";
 import CompanyProfileBuilder from "../../../../builder/CompanyProfileBuilder";
 import { LIMITED_PARTNER_CHECK_YOUR_ANSWERS_URL } from "../../../../../controller/postTransition/url";
-import { countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
+import { capitalize, countOccurrences, getUrl, setLocalesEnabled, testTranslations } from "../../../../utils";
 import { formatDate } from "../../../../../../utils/date-format";
 import { LimitedPartner, PartnerKind } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CONFIRM_LIMITED_PARTNER_PRINCIPAL_OFFICE_ADDRESS_URL, CONFIRM_LIMITED_PARTNER_USUAL_RESIDENTIAL_ADDRESS_URL } from "../../../../../controller/addressLookUp/url/postTransition";
@@ -171,23 +171,23 @@ describe("Limited Partner Check Your Answers Page for Person", () => {
 });
 
 const checkIfValuesInText = (res: request.Response, partner: LimitedPartner, translationText: Record<string, any>) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
+  const partnerData = partner.data as Record<string, any>;
 
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("usual_residential_address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_effective_from")) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      }
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "nationality1") {
+      expect(res.text).toContain(capitalize(value));
+    } else if (key.includes("date_of_birth") && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (key.includes("usual_residential_address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
     }
   }
 };

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -10,7 +10,7 @@ import {
 import { CHECK_YOUR_ANSWERS_URL, REVIEW_LIMITED_PARTNERS_URL, REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL, WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL } from "../../../controller/registration/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { capitalize, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
@@ -696,33 +696,29 @@ const checkIfValuesInText = (
   for (const key in partnerData) {
     const value = partnerData[key];
 
-    if (typeof value === "string" || typeof value === "object") {
-      if (key === "nationality1") {
-        const capitalized = value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
 
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && value) {
-        expect(res.text).toContain(formatDate(value, translationText));
-      } else if (key.includes("address")) {
-        const capitalized = value.address_line_1
-          .split(" ")
-          .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("contribution_sub_types")) {
-        const capitalContributionSubTypesMap: Record<string, string> = {
-          MONEY: translationText.capitalContribution.money,
-          LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
-          SHARES: translationText.capitalContribution.shares,
-          SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
-          ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
-        };
+    if (key === "nationality1") {
+      expect(res.text).toContain(capitalize(value));
+    } else if (key.includes("date_of_birth") && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (key.includes("address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("contribution_sub_types")) {
+      const capitalContributionSubTypesMap: Record<string, string> = {
+        MONEY: translationText.capitalContribution.money,
+        LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
+        SHARES: translationText.capitalContribution.shares,
+        SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
+        ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
+      };
 
-        const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
-        expect(res.text).toContain(str.replaceAll("_", " "));
-      } else {
-        expect(res.text).toContain(value);
-      }
+      const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
+      expect(res.text).toContain(str.split("_").join(" "));
+    } else {
+      expect(res.text).toContain(value);
     }
   }
 };

--- a/src/presentation/test/integration/registration/check-your-answers.test.ts
+++ b/src/presentation/test/integration/registration/check-your-answers.test.ts
@@ -2,15 +2,13 @@ import request from "supertest";
 import app from "../app";
 
 import {
-  GeneralPartner,
-  LimitedPartner,
   Jurisdiction,
   PartnershipType
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CHECK_YOUR_ANSWERS_URL, REVIEW_LIMITED_PARTNERS_URL, REVIEW_PERSONS_WITH_SIGNIFICANT_CONTROL_URL, WILL_LIMITED_PARTNERSHIP_HAVE_PSC_URL } from "../../../controller/registration/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { capitalize, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { checkPartnerValuesInText, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import RegistrationPageType from "../../../controller/registration/PageType";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
@@ -292,13 +290,13 @@ describe("Check Your Answers Page", () => {
       "psc"
     ]);
 
-    checkIfValuesInText(res, generalPartnerPerson, translationText);
+    checkPartnerValuesInText(res, generalPartnerPerson, translationText);
 
-    checkIfValuesInText(res, generalPartnerLegalEntity, translationText);
+    checkPartnerValuesInText(res, generalPartnerLegalEntity, translationText);
 
-    checkIfValuesInText(res, limitedPartnerPerson, translationText);
+    checkPartnerValuesInText(res, limitedPartnerPerson, translationText);
 
-    checkIfValuesInText(res, limitedPartnerLegalEntity, translationText);
+    checkPartnerValuesInText(res, limitedPartnerLegalEntity, translationText);
 
     expect(res.text).toContain(translationText.nationalities.british);
     expect(res.text).toContain(countriesText.countries.unitedStates);
@@ -685,40 +683,3 @@ describe("Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (
-  res: request.Response,
-  partner: GeneralPartner | LimitedPartner,
-  translationText: Record<string, any>
-) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "nationality1") {
-      expect(res.text).toContain(capitalize(value));
-    } else if (key.includes("date_of_birth") && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (key.includes("address")) {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("contribution_sub_types")) {
-      const capitalContributionSubTypesMap: Record<string, string> = {
-        MONEY: translationText.capitalContribution.money,
-        LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
-        SHARES: translationText.capitalContribution.shares,
-        SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
-        ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
-      };
-
-      const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
-      expect(res.text).toContain(str.split("_").join(" "));
-    } else {
-      expect(res.text).toContain(value);
-    }
-  }
-};

--- a/src/presentation/test/integration/transition/check-your-answers.test.ts
+++ b/src/presentation/test/integration/transition/check-your-answers.test.ts
@@ -2,17 +2,14 @@ import request from "supertest";
 import app from "../app";
 
 import {
-  GeneralPartner,
-  LimitedPartner,
   PartnershipType
 } from "@companieshouse/api-sdk-node/dist/services/limited-partnerships";
 import { CHECK_YOUR_ANSWERS_URL } from "../../../controller/transition/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { capitalize, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { checkPartnerValuesInText, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
-import { formatDate } from "../../../../utils/date-format";
 import { TransactionKind } from "../../../../domain/entities/TransactionTypes";
 import TransactionBuilder from "../../builder/TransactionBuilder";
 import TransitionPageType from "../../../controller/transition/PageType";
@@ -25,11 +22,11 @@ describe("Check Your Answers Page", () => {
   const URL = getUrl(CHECK_YOUR_ANSWERS_URL);
   const REDIRECT_URL = getUrl(CONFIRMATION_URL).replace(JOURNEY_TYPE_PARAM, Journey.transition);
 
-  let limitedPartnership;
-  let generalPartnerPerson;
-  let generalPartnerLegalEntity;
-  let limitedPartnerPerson;
-  let limitedPartnerLegalEntity;
+  let limitedPartnership: any;
+  let generalPartnerPerson: any;
+  let generalPartnerLegalEntity: any;
+  let limitedPartnerPerson: any;
+  let limitedPartnerLegalEntity: any;
 
   beforeEach(() => {
     const transaction = new TransactionBuilder().withFilingMode(TransactionKind.transition).build();
@@ -165,13 +162,13 @@ describe("Check Your Answers Page", () => {
         "warningMessageUpdate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerPerson, enTranslationText);
+      checkPartnerValuesInText(res, generalPartnerPerson, enTranslationText);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, enTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, enTranslationText);
 
-      checkIfValuesInText(res, limitedPartnerPerson, enTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerPerson, enTranslationText);
 
-      checkIfValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerLegalEntity, enTranslationText);
 
       expect(res.text).toContain(enTranslationText.nationalities.british);
       expect(res.text).toContain(enTranslationText.countries.unitedStates);
@@ -193,13 +190,13 @@ describe("Check Your Answers Page", () => {
         "warningMessageUpdate"
       ]);
 
-      checkIfValuesInText(res, generalPartnerPerson, cyTranslationText);
+      checkPartnerValuesInText(res, generalPartnerPerson, cyTranslationText);
 
-      checkIfValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
+      checkPartnerValuesInText(res, generalPartnerLegalEntity, cyTranslationText);
 
-      checkIfValuesInText(res, limitedPartnerPerson, cyTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerPerson, cyTranslationText);
 
-      checkIfValuesInText(res, limitedPartnerLegalEntity, cyTranslationText);
+      checkPartnerValuesInText(res, limitedPartnerLegalEntity, cyTranslationText);
 
       expect(res.text).toContain(cyTranslationText.nationalities.british);
       expect(res.text).toContain(cyTranslationText.countries.unitedStates);
@@ -217,29 +214,3 @@ describe("Check Your Answers Page", () => {
     });
   });
 });
-
-const checkIfValuesInText = (
-  res: request.Response,
-  partner: GeneralPartner | LimitedPartner,
-  translationText: Record<string, any>
-) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
-    }
-
-    if (key === "nationality1") {
-      expect(res.text).toContain(capitalize(value));
-    } else if (key.includes("date_of_birth") && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (key.includes("address")) {
-      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else {
-      expect(res.text).toContain(value);
-    }
-  }
-};

--- a/src/presentation/test/integration/transition/check-your-answers.test.ts
+++ b/src/presentation/test/integration/transition/check-your-answers.test.ts
@@ -9,7 +9,7 @@ import {
 import { CHECK_YOUR_ANSWERS_URL } from "../../../controller/transition/url";
 import { appDevDependencies } from "../../../../config/dev-dependencies";
 import LimitedPartnershipBuilder from "../../builder/LimitedPartnershipBuilder";
-import { getUrl, setLocalesEnabled, testTranslations } from "../../utils";
+import { capitalize, getUrl, setLocalesEnabled, testTranslations } from "../../utils";
 import GeneralPartnerBuilder from "../../builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "../../builder/LimitedPartnerBuilder";
 import { formatDate } from "../../../../utils/date-format";
@@ -223,22 +223,23 @@ const checkIfValuesInText = (
   partner: GeneralPartner | LimitedPartner,
   translationText: Record<string, any>
 ) => {
-  for (const key in partner.data) {
-    if (typeof partner.data[key] === "string" || typeof partner.data[key] === "object") {
-      if (key === "nationality1") {
-        const capitalized = partner.data[key].charAt(0).toUpperCase() + partner.data[key].slice(1).toLowerCase();
-        expect(res.text).toContain(capitalized);
-      } else if (key.includes("date_of_birth") && partner.data[key]) {
-        expect(res.text).toContain(formatDate(partner.data[key], translationText));
-      } else if (key.includes("address")) {
-        const capitalized = partner.data[key].address_line_1
-          .split(" ")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-          .join(" ");
-        expect(res.text).toContain(capitalized);
-      } else {
-        expect(res.text).toContain(partner.data[key]);
-      }
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "nationality1") {
+      expect(res.text).toContain(capitalize(value));
+    } else if (key.includes("date_of_birth") && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (key.includes("address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else {
+      expect(res.text).toContain(value);
     }
   }
 };

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -7,6 +7,7 @@ import GeneralPartnerBuilder from "./builder/GeneralPartnerBuilder";
 import LimitedPartnerBuilder from "./builder/LimitedPartnerBuilder";
 import request from "supertest";
 import PersonWithSignificantControlBuilder from "./builder/PersonWithSignificantControlBuilder";
+import { formatDate } from "../../utils/date-format";
 
 export const setLocalesEnabled = (bool: boolean) => {
   jest.spyOn(config, "isLocalesEnabled").mockReturnValue(bool);
@@ -131,4 +132,54 @@ export const createPersonWithSignificantControl = (url: string, urlToCompare: st
     personWithSignificantControl.build()
   ]);
   return personWithSignificantControl;
+};
+
+export const checkLegalEntityValuesInText = (
+  res: request.Response,
+  partner: GeneralPartner | LimitedPartner,
+  translationText: Record<string, any>
+) => {
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "principal_office_address") {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (!key.includes("address")) {
+      expect(res.text).toContain(value);
+    }
+  }
+};
+
+export const checkPersonValuesInText = (
+  res: request.Response,
+  partner: GeneralPartner | LimitedPartner,
+  translationText: Record<string, any>
+) => {
+  const partnerData = partner.data as Record<string, any>;
+
+  for (const key in partnerData) {
+    const value = partnerData[key];
+
+    if (typeof value !== "string" && typeof value !== "object") {
+      continue;
+    }
+
+    if (key === "nationality1") {
+      expect(res.text).toContain(capitalize(value));
+    } else if (key.includes("date_of_birth") && value) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    } else if (key.includes("usual_residential_address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("date_effective_from")) {
+      expect(res.text).toContain(formatDate(value, translationText));
+    }
+  }
 };

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -134,10 +134,9 @@ export const createPersonWithSignificantControl = (url: string, urlToCompare: st
   return personWithSignificantControl;
 };
 
-export const checkLegalEntityValuesInText = (
-  res: request.Response,
+const forEachPartnerValue = (
   partner: GeneralPartner | LimitedPartner,
-  translationText: Record<string, any>
+  handler: (key: string, value: any) => void
 ) => {
   const partnerData = partner.data as Record<string, any>;
 
@@ -148,14 +147,46 @@ export const checkLegalEntityValuesInText = (
       continue;
     }
 
+    handler(key, value);
+  }
+};
+
+const checkCommonPartnerValue = (
+  key: string,
+  value: any,
+  res: request.Response,
+  translationText: Record<string, any>
+): boolean => {
+  if (key === "nationality1") {
+    expect(res.text).toContain(capitalize(value));
+    return true;
+  } else if (key.includes("date_of_birth") && value) {
+    expect(res.text).toContain(formatDate(value, translationText));
+    return true;
+  } else if (key.includes("date_effective_from") && value) {
+    expect(res.text).toContain(formatDate(value, translationText));
+    return true;
+  }
+
+  return false;
+};
+
+export const checkLegalEntityValuesInText = (
+  res: request.Response,
+  partner: GeneralPartner | LimitedPartner,
+  translationText: Record<string, any>
+) => {
+  forEachPartnerValue(partner, (key, value) => {
+    if (checkCommonPartnerValue(key, value, res, translationText)) {
+      return;
+    }
+
     if (key === "principal_office_address") {
       expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
     } else if (!key.includes("address")) {
       expect(res.text).toContain(value);
     }
-  }
+  });
 };
 
 export const checkPersonValuesInText = (
@@ -163,23 +194,42 @@ export const checkPersonValuesInText = (
   partner: GeneralPartner | LimitedPartner,
   translationText: Record<string, any>
 ) => {
-  const partnerData = partner.data as Record<string, any>;
-
-  for (const key in partnerData) {
-    const value = partnerData[key];
-
-    if (typeof value !== "string" && typeof value !== "object") {
-      continue;
+  forEachPartnerValue(partner, (key, value) => {
+    if (checkCommonPartnerValue(key, value, res, translationText)) {
+      return;
     }
 
-    if (key === "nationality1") {
-      expect(res.text).toContain(capitalize(value));
-    } else if (key.includes("date_of_birth") && value) {
-      expect(res.text).toContain(formatDate(value, translationText));
-    } else if (key.includes("usual_residential_address")) {
+    if (key.includes("usual_residential_address")) {
       expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
-    } else if (key.includes("date_effective_from")) {
-      expect(res.text).toContain(formatDate(value, translationText));
     }
-  }
+  });
+};
+
+export const checkPartnerValuesInText = (
+  res: request.Response,
+  partner: GeneralPartner | LimitedPartner,
+  translationText: Record<string, any>
+) => {
+  forEachPartnerValue(partner, (key, value) => {
+    if (checkCommonPartnerValue(key, value, res, translationText)) {
+      return;
+    }
+
+    if (key.includes("address")) {
+      expect(res.text).toContain(value.address_line_1.split(" ").map(capitalize).join(" "));
+    } else if (key.includes("contribution_sub_types")) {
+      const capitalContributionSubTypesMap: Record<string, string> = {
+        MONEY: translationText.capitalContribution.money,
+        LAND_OR_PROPERTY: translationText.capitalContribution.landOrProperty,
+        SHARES: translationText.capitalContribution.shares,
+        SERVICES_OR_GOODS: translationText.capitalContribution.servicesOrGoods,
+        ANY_OTHER_ASSET: translationText.capitalContribution.anyOtherAsset
+      };
+
+      const str = value.map((word: string) => capitalContributionSubTypesMap[word]).join(" / ");
+      expect(res.text).toContain(str.split("_").join(" "));
+    } else {
+      expect(res.text).toContain(value);
+    }
+  });
 };

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -39,6 +39,8 @@ export const getUrl = (url: string) => {
   return appDevDependencies.addressLookUpController.insertIdsInUrl(url, ids);
 };
 
+export const capitalize = (value: string): string => value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+
 export const toEscapedHtml = (input: string) => {
   return input
     .replace(/&/g, "&amp;")

--- a/src/presentation/test/utils.ts
+++ b/src/presentation/test/utils.ts
@@ -160,10 +160,7 @@ const checkCommonPartnerValue = (
   if (key === "nationality1") {
     expect(res.text).toContain(capitalize(value));
     return true;
-  } else if (key.includes("date_of_birth") && value) {
-    expect(res.text).toContain(formatDate(value, translationText));
-    return true;
-  } else if (key.includes("date_effective_from") && value) {
+  } else if ((key.includes("date_of_birth") || key.includes("date_effective_from")) && value) {
     expect(res.text).toContain(formatDate(value, translationText));
     return true;
   }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2194


### Change description
Simplify the partner value checks in check-your-answers-tests

This pull request refactors several integration tests for the "Check Your Answers" pages across registration, transition, and post-transition journeys. The main focus is on improving code reuse and maintainability by extracting and centralizing repeated logic for checking partner values in the test responses. The redundant, inline helper functions are removed from individual test files and replaced with shared utility functions.

**Test code refactoring and simplification:**

* Replaced duplicated `checkIfValuesInText` helper functions in multiple test files with shared utility functions such as `checkPartnerValuesInText`, `checkPersonValuesInText`, and `checkLegalEntityValuesInText` imported from `utils`. This change reduces code duplication and centralizes test logic. [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL4-R12) [[2]](diffhunk://#diff-1db674ddd838c97f36ff9bcea606a8076f22079355a7f9b7120c0be7e9c20fdcL8-R9) [[3]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL7-R8) [[4]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L7-R8) [[5]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L5-R11) [[6]](diffhunk://#diff-c83665e3173d77192eb077dcb328c3ec9407b3067baf92561de58ce1ac5ef551L5-L15)
* Updated all test cases to use the new shared utility functions for checking partner values in the response text, replacing calls to the removed inline helper functions. [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL118-R117) [[2]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL139-R138) [[3]](diffhunk://#diff-1db674ddd838c97f36ff9bcea606a8076f22079355a7f9b7120c0be7e9c20fdcL89-R88) [[4]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL89-R88) [[5]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L101-R100) [[6]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L118-R117) [[7]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L295-R299) [[8]](diffhunk://#diff-c83665e3173d77192eb077dcb328c3ec9407b3067baf92561de58ce1ac5ef551L168-R171)
* Removed the old inline `checkIfValuesInText` function definitions from all affected test files. [[1]](diffhunk://#diff-3ac42da6c9ac60e8e16ebc8f717f2a61c79a74d035e85de1f2d3122175524f1eL161-L178) [[2]](diffhunk://#diff-1db674ddd838c97f36ff9bcea606a8076f22079355a7f9b7120c0be7e9c20fdcL112-L133) [[3]](diffhunk://#diff-60dc21b23d372726ae5e4af0ddefa64ed9a1ba7ebfd5aa95c7e0d3afd7c71c7cL139-L156) [[4]](diffhunk://#diff-89de95436754df306bf57c8b4c0e9ac4ca7b95c8130ee7da309b92deba2b9283L173-L194) [[5]](diffhunk://#diff-0206000ef69b27d206ea1b5ff12ee56fb5ea2a7b5cf972c10f0d213ee1488f88L688-L728)
* Minor type annotation improvements for partner variables in `transition/check-your-answers.test.ts` for better clarity.

These changes collectively improve the maintainability and readability of the test suite by ensuring that logic for checking partner details is consistent and managed in a single location.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.